### PR TITLE
Attempt to fix endless exec wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ brew uninstall protobuf
 
 ### grpcio for python
 ```sh
-pip install grpcio-tools
+pip install grpcio grpcio-tools
 ```
+(If grpcio* is already installed you should probably update it by including '--upgrade' to the above pip command)
 
 ### docopt for python
 ```sh

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -256,7 +256,8 @@ if the command fails and we cannot get the exit code from the command, return FA
 that prevented getting the exit code.
 */
 func (p *osProcess) Wait() (result execer.ProcessStatus) {
-	defer p.wg.Wait()
+	// Wait for the output goroutines to finish then wait on the process itself to release resources.
+	p.wg.Wait()
 	pid := p.cmd.Process.Pid
 	err := p.cmd.Wait()
 

--- a/runner/runners/single_test.go
+++ b/runner/runners/single_test.go
@@ -106,12 +106,12 @@ func TestAbort(t *testing.T) {
 }
 
 func TestMemCap(t *testing.T) {
-	// Command to increase memory by 10MB every .1s until we hit 50MB after .5s.
-	// Test that limiting the memory to 25MB causes the command to abort.
-	str := `import time; exec("x=[]\nfor i in range(5):\n x.append(' ' * 10*1024*1024)\n time.sleep(.1)")`
+	// Command to increase memory by 1MB every .1s until we hit 50MB after 5s.
+	// Test that limiting the memory to 10MB causes the command to abort.
+	str := `import time; exec("x=[]\nfor i in range(50):\n x.append(' ' * 1024*1024)\n time.sleep(.1)")`
 	cmd := &runner.Command{Argv: []string{"python", "-c", str}}
 	tmp, _ := temp.TempDirDefault()
-	e := os_execer.NewBoundedExecer(execer.Memory(25*1024*1024), stats.NilStatsReceiver())
+	e := os_execer.NewBoundedExecer(execer.Memory(10*1024*1024), stats.NilStatsReceiver())
 	r := NewSingleRunner(e, snapshots.MakeNoopFiler(tmp.Dir), nil, NewNullOutputCreator(), tmp, nil)
 	if _, err := r.Run(cmd); err != nil {
 		t.Fatalf(err.Error())
@@ -122,7 +122,7 @@ func TestMemCap(t *testing.T) {
 		States:  runner.MaskForState(runner.FAILED),
 	}
 	// Travis may be slow, wait a super long time? This may also be necessary due to slow debug output from os_execer? TBD.
-	if runs, _, err := r.Query(query, runner.Wait{Timeout: 5 * time.Second}); err != nil {
+	if runs, _, err := r.Query(query, runner.Wait{Timeout: 10 * time.Second}); err != nil {
 		t.Fatalf(err.Error())
 	} else if len(runs) != 1 || !strings.Contains(runs[0].Error, "MemoryCap") {
 		status, _, err := r.StatusAll()

--- a/sched/scheduler/cluster_state.go
+++ b/sched/scheduler/cluster_state.go
@@ -14,7 +14,7 @@ import (
 const noJob = ""
 const noTask = ""
 const defaultMaxLostDuration = time.Minute
-const defaultMaxFlakyDuration = time.Minute
+const defaultMaxFlakyDuration = 15 * time.Minute
 
 var nilTime = time.Time{}
 


### PR DESCRIPTION
Attempt to fix endless exec wait. Increased flaky node probation from 1m->15m. Loosened mem_cap test requirements.