### PR TITLE
Most of the gitdb requests should defer thread safety to the git binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,11 @@ test-unit-property-integration: fs_util
 	# Runs all tests including integration and property tests
 	go test -race -timeout 120s -tags="integration property_test" $$(go list ./... | grep -v /vendor/ | grep -v /cmd/) $(TRAVIS_FILTER)
 
-test-unit-property: fs_util
+test-unit-property:
 	# Runs only unit tests and property tests
 	go test -race -timeout 120s -tags="property_test" $$(go list ./... | grep -v /vendor/ | grep -v /cmd/) $(TRAVIS_FILTER)
 
-test-unit: fs_util
+test-unit:
 	# Runs only unit tests
 	# Only invoked manually so we don't need to modify output
 	go test -race -timeout 120s $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)

--- a/Makefile
+++ b/Makefile
@@ -57,15 +57,15 @@ vet:
 coverage:
 	sh testCoverage.sh $(TRAVIS_FILTER)
 
-test-unit-property-integration:
+test-unit-property-integration: fs_util
 	# Runs all tests including integration and property tests
 	go test -race -timeout 120s -tags="integration property_test" $$(go list ./... | grep -v /vendor/ | grep -v /cmd/) $(TRAVIS_FILTER)
 
-test-unit-property:
+test-unit-property: fs_util
 	# Runs only unit tests and property tests
 	go test -race -timeout 120s -tags="property_test" $$(go list ./... | grep -v /vendor/ | grep -v /cmd/) $(TRAVIS_FILTER)
 
-test-unit:
+test-unit: fs_util
 	# Runs only unit tests
 	# Only invoked manually so we don't need to modify output
 	go test -race -timeout 120s $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)

--- a/sched/scheduler/job_state.go
+++ b/sched/scheduler/job_state.go
@@ -18,6 +18,8 @@ type jobState struct {
 	TasksCompleted int          //number of tasks that've been marked completed so far.
 	TasksRunning   int          //number of tasks that've been scheduled or started.
 	JobKilled      bool         //indicates the job was killed
+	TimeCreated    time.Time    //when was this job first created
+	TimeMarker     time.Time    //when was this job last marked (i.e. for reporting purposes)
 }
 
 // Contains all the information for a specified task
@@ -56,6 +58,8 @@ func newJobState(job *sched.Job, saga *saga.Saga, taskDurations map[string]avera
 		TasksCompleted: 0,
 		TasksRunning:   0,
 		JobKilled:      false,
+		TimeCreated:    time.Now(),
+		TimeMarker:     time.Now(),
 	}
 
 	for _, taskDef := range job.Def.Tasks {

--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -480,6 +480,7 @@ func (s *statefulScheduler) updateStats() {
 		}
 
 		if time.Now().Sub(job.TimeMarker) > LongJobDuration {
+			job.TimeMarker = time.Now()
 			log.WithFields(
 				log.Fields{
 					"requestor":      job.Job.Def.Requestor,

--- a/snapshot/bazel/fs_util_test.go
+++ b/snapshot/bazel/fs_util_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package bazel
 
 import (


### PR DESCRIPTION
We observed congestion in apiserver while trying to hit the /view endpoint. At a minimum we shouldn't be blocking concurrent-capable requests.