### PR TITLE
Fixed bug where sched would not terminate jobs due to stuck tasks.

### DIFF
--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -802,9 +802,15 @@ func (s *statefulScheduler) scheduleTasks() {
 					s.taskDurations[taskID].update(time.Now().Sub(tRunner.startTime))
 				}
 
-				// Tasks from the same job or related jobs will never preempt each other,
-				//  so we only need to check jobId to determine preemption.
-				if nodeSt.runningJob != jobID {
+				// If the jobID or taskID has changed, the assigned node has been preempted, simply return early.
+				// However, if nodeState has changed (i.e same node deleted then re-added), we must clean up before returning.
+				nodeStInstance, ok := s.clusterState.getNodeState(nodeSt.node.Id())
+				nodeStChanged := !ok || &nodeStInstance.readyCh != &nodeSt.readyCh
+				if nodeStChanged {
+					preempted := true
+					s.getJob(jobID).errorRunningTask(taskID, errors.New("Task failed: node hiccup"), preempted)
+				}
+				if nodeSt.runningJob != jobID || nodeSt.runningTask != taskID || nodeStChanged {
 					log.WithFields(
 						log.Fields{
 							"node":        nodeSt.node,
@@ -812,6 +818,7 @@ func (s *statefulScheduler) scheduleTasks() {
 							"taskID":      taskID,
 							"runningJob":  nodeSt.runningJob,
 							"runningTask": nodeSt.runningTask,
+							"nodeStOk":    !nodeStChanged,
 							"tag":         tag,
 						}).Info("Task preempted")
 					return


### PR DESCRIPTION
Observed sequence resulting in stuck task:

-TaskA is running and there is a cluster hiccup causing its node to be suspended then deleted
-The node gets re-added and scheduler blindly kills any running tasks, TaskA in this case
-A new TaskB gets scheduled on the node and starts running
-The goroutine for TaskA returns, sees TaskB, and exits without any cleanup or rescheduling because it thinks cleanup already happened