### PR TITLE
runner/bazel - support for ingestion of std* logs and Output data for Bazel commands

### DIFF
--- a/bazel/execution/service.go
+++ b/bazel/execution/service.go
@@ -159,7 +159,7 @@ func execReqToScoot(req *remoteexecution.ExecuteRequest, actionSha string) (resu
 	task.Command.Argv = []string{"BZ_PLACEHOLDER"}
 	task.Command.EnvVars = make(map[string]string)
 	task.Command.Timeout = d
-	task.Command.SnapshotID = bazel.DigestSnapshotID(req.GetAction().GetInputRootDigest())
+	task.Command.SnapshotID = bazel.SnapshotIDFromDigest(req.GetAction().GetInputRootDigest())
 	task.Command.ExecuteRequest = &bazelapi.ExecuteRequest{Request: *req}
 
 	result.Tasks = append(result.Tasks, task)

--- a/bazel/snapshot_test.go
+++ b/bazel/snapshot_test.go
@@ -1,0 +1,70 @@
+package bazel
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	remoteexecution "google.golang.org/genproto/googleapis/devtools/remoteexecution/v1test"
+)
+
+var emptySha string = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+var size5 int64 = 5
+
+func TestGetShaAndSize(t *testing.T) {
+	id := SnapshotID(emptySha, size5)
+	resultSha, resultSize, err := GetShaAndSize(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resultSha != emptySha {
+		t.Fatalf("Expected %s, got %s", emptySha, resultSha)
+	}
+	if resultSize != size5 {
+		t.Fatalf("Expected %d, got %d", size5, resultSize)
+	}
+}
+
+func TestSplitIdValid(t *testing.T) {
+	id := SnapshotID(emptySha, size5)
+	result, err := splitID(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{SnapshotIDPrefix, emptySha, "5"}
+	for idx, _ := range result {
+		if result[idx] != expected[idx] {
+			t.Fatalf("Expected %v, received %v", expected, result)
+		}
+	}
+}
+
+func TestSplitIdInvalid(t *testing.T) {
+	id := fmt.Sprintf("bs-%s-%d", emptySha, size5)
+	_, err := splitID(id)
+	if err == nil || !strings.Contains(err.Error(), InvalidIDMsg) {
+		t.Fatalf("Expected error to contain \"%s\", received \"%v\"", InvalidIDMsg, err)
+	}
+}
+
+func TestSnapshotIDFromDigest(t *testing.T) {
+	d := &remoteexecution.Digest{Hash: emptySha, SizeBytes: size5}
+	id := SnapshotIDFromDigest(d)
+	if err := ValidateID(id); err != nil {
+		t.Fatalf("Unexpected invalid snapshot ID: %s", err)
+	}
+}
+
+func TestGetDigestFromSnapshotID(t *testing.T) {
+	id := SnapshotID(emptySha, size5)
+	d, err := DigestFromSnapshotID(id)
+	if err != nil {
+		t.Fatalf("Error creating digest from SnapshotID: %s", err)
+	}
+	if d.GetHash() != emptySha {
+		t.Fatalf("Expected %s, got %s", emptySha, d.GetHash())
+	}
+	if d.GetSizeBytes() != size5 {
+		t.Fatalf("Expected %d, got %d", size5, d.GetSizeBytes())
+	}
+}

--- a/binaries/bzutil/main.go
+++ b/binaries/bzutil/main.go
@@ -18,6 +18,7 @@ import (
 	remoteexecution "google.golang.org/genproto/googleapis/devtools/remoteexecution/v1test"
 
 	"github.com/twitter/scoot/bazel/cas"
+	"github.com/twitter/scoot/common/dialer"
 	"github.com/twitter/scoot/common/log/hooks"
 	scootproto "github.com/twitter/scoot/common/proto"
 	"github.com/twitter/scoot/scootapi"
@@ -68,8 +69,9 @@ func main() {
 	}
 
 	// upload command to CAS
+	r := dialer.NewConstantResolver(*casAddr)
 	digest := &remoteexecution.Digest{Hash: hash, SizeBytes: size}
-	err = cas.ByteStreamWrite(*casAddr, digest, bytes)
+	err = cas.ByteStreamWrite(r, digest, bytes)
 	if err != nil {
 		log.Fatalf("Error writing to CAS: %s", err)
 	}

--- a/runner/runners/bazel.go
+++ b/runner/runners/bazel.go
@@ -6,31 +6,48 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
 
 	"github.com/golang/protobuf/proto"
 	log "github.com/sirupsen/logrus"
 	remoteexecution "google.golang.org/genproto/googleapis/devtools/remoteexecution/v1test"
 
+	"github.com/twitter/scoot/bazel"
 	"github.com/twitter/scoot/bazel/cas"
 	"github.com/twitter/scoot/bazel/execution/bazelapi"
 	"github.com/twitter/scoot/runner"
+	"github.com/twitter/scoot/runner/execer"
+	"github.com/twitter/scoot/snapshot"
 	bzsnapshot "github.com/twitter/scoot/snapshot/bazel"
 )
+
+// Preliminary setup for handling Bazel commands - verify Filer and populate command
+func preProcessBazel(filer snapshot.Filer, cmd *runner.Command) error {
+	bzFiler, ok := filer.(*bzsnapshot.BzFiler)
+	if !ok {
+		return fmt.Errorf("Filer could not be asserted as type BzFiler")
+	}
+	if cmd.ExecuteRequest == nil {
+		return fmt.Errorf("Nil ExecuteRequest data in Command with RunType Bazel")
+	}
+	if err := fetchBazelCommand(bzFiler, cmd); err != nil {
+		return fmt.Errorf("Error retrieving Bazel command data: %v", err)
+	}
+	log.Infof("Worker running with updated command arguments: %q", cmd.Argv)
+	return nil
+}
 
 // Get the Bazel Command from the embedded ExecuteRequest digest,
 // and populate the runner.Command's Argv and Env fields
 func fetchBazelCommand(bzFiler *bzsnapshot.BzFiler, cmd *runner.Command) error {
 	digest := cmd.ExecuteRequest.Request.GetAction().GetCommandDigest()
 
-	casAddr, err := bzFiler.CASResolver.Resolve()
+	log.Info("Fetching Bazel Command data from CAS server")
+	bzCommandBytes, err := cas.ByteStreamRead(bzFiler.CASResolver, digest)
 	if err != nil {
-		return fmt.Errorf("Filer could not resolve a CAS server: %s", err)
-	}
-	log.Infof("Fetching Bazel Command data from CAS server %s", casAddr)
-
-	bzCommandBytes, err := cas.ByteStreamRead(casAddr, digest)
-	if err != nil {
-		log.Errorf("Error reading command data from CAS server %s: %s", casAddr, err)
+		log.Errorf("Error reading command data from CAS server: %s", err)
 		return err
 	}
 	bzCommand := &remoteexecution.Command{}
@@ -47,9 +64,52 @@ func fetchBazelCommand(bzFiler *bzsnapshot.BzFiler, cmd *runner.Command) error {
 	return nil
 }
 
-// TODO org, naming, logs, comments, tests
+// Post-execer actions for Bazel tasks - upload outputs and std* logs, format result structure
+func postProcessBazel(filer snapshot.Filer,
+	cmd *runner.Command,
+	coDir string,
+	stdout, stderr runner.Output,
+	st execer.ProcessStatus) (*bazelapi.ActionResult, error) {
+	bzFiler, ok := filer.(*bzsnapshot.BzFiler)
+	if !ok {
+		return nil, fmt.Errorf("Filer could not be asserted as type BzFiler")
+	}
+	log.Info("Processing Bazel outputs to CAS")
 
-func ingestFile(bzFiler *bzsnapshot.BzFiler, path string) (*remoteexecution.Digest, error) {
+	stdoutDigest, err := writeFileToCAS(bzFiler, stdout.AsFile())
+	if err != nil {
+		return nil, fmt.Errorf("Error ingesting stdout to CAS: %s", err)
+	}
+	stderrDigest, err := writeFileToCAS(bzFiler, stderr.AsFile())
+	if err != nil {
+		return nil, fmt.Errorf("Error ingesting stderr to CAS: %s", err)
+	}
+
+	outputFiles, err := ingestOutputFiles(bzFiler, cmd, coDir)
+	if err != nil {
+		return nil, fmt.Errorf("Error ingesting OutputFiles: %s", err)
+	}
+	outputDirs, err := ingestOutputDirs(bzFiler, cmd, coDir)
+	if err != nil {
+		return nil, fmt.Errorf("Error ingesting OutputFiles: %s", err)
+	}
+
+	return &bazelapi.ActionResult{
+		Result: remoteexecution.ActionResult{
+			OutputFiles:       outputFiles,
+			OutputDirectories: outputDirs,
+			ExitCode:          int32(st.ExitCode),
+			StdoutDigest:      stdoutDigest,
+			StderrDigest:      stderrDigest,
+		},
+	}, nil
+}
+
+// Write a file's bytes to the BzFiler's CAS, returning the Digest of the uploaded file.
+// This is distinct from using a Filer to Ingest data into the CAS,
+// which allows for Filer-implementation-specific behavior that could alter the bytes and expected digest.
+// (Our typical BzFiler use case is uploading Files that include relative path and other protobuf data)
+func writeFileToCAS(bzFiler *bzsnapshot.BzFiler, path string) (*remoteexecution.Digest, error) {
 	bytes, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading file %s as bytes: %s", path, err)
@@ -57,47 +117,101 @@ func ingestFile(bzFiler *bzsnapshot.BzFiler, path string) (*remoteexecution.Dige
 	sha := fmt.Sprintf("%x", sha256.Sum256(bytes))
 	digest := &remoteexecution.Digest{Hash: sha, SizeBytes: int64(len(bytes))}
 
-	casAddr, err := bzFiler.CASResolver.Resolve()
+	err = cas.ByteStreamWrite(bzFiler.CASResolver, digest, bytes)
 	if err != nil {
-		return nil, fmt.Errorf("Filer could not resolve a CAS server: %s", err)
-	}
-
-	err = cas.ByteStreamWrite(casAddr, digest, bytes)
-	if err != nil {
-		return nil, fmt.Errorf("Error writing data to CAS server %s: %s", casAddr, err)
+		return nil, fmt.Errorf("Error writing data to CAS server: %s", err)
 	}
 
 	return digest, nil
 }
 
+// Ingest any of a command's OutputFiles that are specified in a Bazel ExecuteRequest.
+// Files that do not exist are skipped, and this is not considered an error,
+// but we do error if a specified "file" path results in a directory.
+// Files located are Ingested in to the CAS via the BzFiler
 func ingestOutputFiles(bzFiler *bzsnapshot.BzFiler, cmd *runner.Command, coDir string) ([]*remoteexecution.OutputFile, error) {
 	outputFiles := []*remoteexecution.OutputFile{}
-	for _, of := range cmd.ExecuteRequest.Request.GetAction().GetOutputFiles() {
-		// join/normalize coDir and of
-		// check file is there and stat executable ideally at same time
-		// if it's there call bzFiler.Ingest and get digest from snapshot, also get relative path (of w/ leading slash enforced?)
-		fmt.Println(of)
+	for _, relPath := range cmd.ExecuteRequest.Request.GetAction().GetOutputFiles() {
+		relPath = path.Join("/", relPath)
+		absPath := filepath.Join(coDir, relPath)
+		info, err := os.Stat(absPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				log.Infof("Output file %s not present", absPath)
+			} else {
+				return nil, fmt.Errorf("Error Statting output file %s: %s", absPath, err)
+			}
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("Expected output file %s not a regular file", absPath)
+		}
+		// check executable bits
+		executable := (info.Mode() & 0111) > 0
+
+		digest, err := ingestPath(bzFiler, absPath)
+		if err != nil {
+			return nil, err
+		}
+		log.Infof("Ingested OutputFile: %s", relPath)
+
+		of := &remoteexecution.OutputFile{
+			Path:         relPath,
+			Digest:       digest,
+			IsExecutable: executable,
+		}
+		outputFiles = append(outputFiles, of)
 	}
 	return outputFiles, nil
 }
 
+// Ingest any of a command's OutputDirectories that are specified in a Bazel ExecuteRequest.
+// Directories that do not exist are skipped, and this is not considered an error,
+// but we do error if a specified "directory" path results in a file.
+// Directories located are Ingested in to the CAS via the BzFiler
 func ingestOutputDirs(bzFiler *bzsnapshot.BzFiler, cmd *runner.Command, coDir string) ([]*remoteexecution.OutputDirectory, error) {
 	outputDirs := []*remoteexecution.OutputDirectory{}
+	for _, relPath := range cmd.ExecuteRequest.Request.GetAction().GetOutputDirectories() {
+		relPath = path.Join("/", relPath)
+		absPath := filepath.Join(coDir, relPath)
+		info, err := os.Stat(absPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				log.Infof("Output dir %s not present", absPath)
+			} else {
+				return nil, fmt.Errorf("Error Statting output dir %s: %s", absPath, err)
+			}
+			continue
+		}
+		if !info.Mode().IsDir() {
+			return nil, fmt.Errorf("Expected output dir %s not a directory", absPath)
+		}
+
+		digest, err := ingestPath(bzFiler, absPath)
+		if err != nil {
+			return nil, err
+		}
+		log.Infof("Ingested OutputDirectory: %s", relPath)
+
+		od := &remoteexecution.OutputDirectory{
+			Path:       relPath,
+			TreeDigest: digest,
+		}
+		outputDirs = append(outputDirs, od)
+	}
 	return outputDirs, nil
 }
 
-func getActionResult(ofs []*remoteexecution.OutputFile,
-	ods []*remoteexecution.OutputDirectory,
-	rc int32,
-	outD *remoteexecution.Digest,
-	errD *remoteexecution.Digest) *bazelapi.ActionResult {
-	return &bazelapi.ActionResult{
-		Result: remoteexecution.ActionResult{
-			OutputFiles:       ofs,
-			OutputDirectories: ods,
-			ExitCode:          rc,
-			StdoutDigest:      outD,
-			StderrDigest:      errD,
-		},
+// Ingest a file into the BzFiler, which can store to a CAS. Take the resulting SnapshotID
+// from Ingestion and return a Bazel Digest (used for direct retrieval from CAS by a client)
+func ingestPath(bzFiler *bzsnapshot.BzFiler, absPath string) (*remoteexecution.Digest, error) {
+	id, err := bzFiler.Ingest(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("Error Ingesting output file %s: %s", absPath, err)
 	}
+	digest, err := bazel.DigestFromSnapshotID(id)
+	if err != nil {
+		return nil, fmt.Errorf("Error converting ingested snapshot ID %s to digest: %s", id, err)
+	}
+	return digest, nil
 }

--- a/runner/runners/bazel.go
+++ b/runner/runners/bazel.go
@@ -3,13 +3,16 @@ package runners
 // Bazel-related logic for runners
 
 import (
+	"crypto/sha256"
 	"fmt"
+	"io/ioutil"
 
 	"github.com/golang/protobuf/proto"
 	log "github.com/sirupsen/logrus"
 	remoteexecution "google.golang.org/genproto/googleapis/devtools/remoteexecution/v1test"
 
 	"github.com/twitter/scoot/bazel/cas"
+	"github.com/twitter/scoot/bazel/execution/bazelapi"
 	"github.com/twitter/scoot/runner"
 	bzsnapshot "github.com/twitter/scoot/snapshot/bazel"
 )
@@ -17,9 +20,6 @@ import (
 // Get the Bazel Command from the embedded ExecuteRequest digest,
 // and populate the runner.Command's Argv and Env fields
 func fetchBazelCommand(bzFiler *bzsnapshot.BzFiler, cmd *runner.Command) error {
-	if cmd.ExecuteRequest == nil {
-		return fmt.Errorf("Command has no ExecuteRequest data")
-	}
 	digest := cmd.ExecuteRequest.Request.GetAction().GetCommandDigest()
 
 	casAddr, err := bzFiler.CASResolver.Resolve()
@@ -45,4 +45,59 @@ func fetchBazelCommand(bzFiler *bzsnapshot.BzFiler, cmd *runner.Command) error {
 	}
 
 	return nil
+}
+
+// TODO org, naming, logs, comments, tests
+
+func ingestFile(bzFiler *bzsnapshot.BzFiler, path string) (*remoteexecution.Digest, error) {
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading file %s as bytes: %s", path, err)
+	}
+	sha := fmt.Sprintf("%x", sha256.Sum256(bytes))
+	digest := &remoteexecution.Digest{Hash: sha, SizeBytes: int64(len(bytes))}
+
+	casAddr, err := bzFiler.CASResolver.Resolve()
+	if err != nil {
+		return nil, fmt.Errorf("Filer could not resolve a CAS server: %s", err)
+	}
+
+	err = cas.ByteStreamWrite(casAddr, digest, bytes)
+	if err != nil {
+		return nil, fmt.Errorf("Error writing data to CAS server %s: %s", casAddr, err)
+	}
+
+	return digest, nil
+}
+
+func ingestOutputFiles(bzFiler *bzsnapshot.BzFiler, cmd *runner.Command, coDir string) ([]*remoteexecution.OutputFile, error) {
+	outputFiles := []*remoteexecution.OutputFile{}
+	for _, of := range cmd.ExecuteRequest.Request.GetAction().GetOutputFiles() {
+		// join/normalize coDir and of
+		// check file is there and stat executable ideally at same time
+		// if it's there call bzFiler.Ingest and get digest from snapshot, also get relative path (of w/ leading slash enforced?)
+		fmt.Println(of)
+	}
+	return outputFiles, nil
+}
+
+func ingestOutputDirs(bzFiler *bzsnapshot.BzFiler, cmd *runner.Command, coDir string) ([]*remoteexecution.OutputDirectory, error) {
+	outputDirs := []*remoteexecution.OutputDirectory{}
+	return outputDirs, nil
+}
+
+func getActionResult(ofs []*remoteexecution.OutputFile,
+	ods []*remoteexecution.OutputDirectory,
+	rc int32,
+	outD *remoteexecution.Digest,
+	errD *remoteexecution.Digest) *bazelapi.ActionResult {
+	return &bazelapi.ActionResult{
+		Result: remoteexecution.ActionResult{
+			OutputFiles:       ofs,
+			OutputDirectories: ods,
+			ExitCode:          rc,
+			StdoutDigest:      outD,
+			StderrDigest:      errD,
+		},
+	}
 }

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -107,6 +107,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 
 	go func() {
 		if cmd.SnapshotID == "" {
+			// TODO: we don't want this logic to live here, these decisions should be made at a higher level.
 			if len(cmd.Argv) > 0 && cmd.Argv[0] != execers.UseSimExecerArg {
 				log.WithFields(
 					log.Fields{

--- a/sched/scheduler/cluster_state.go
+++ b/sched/scheduler/cluster_state.go
@@ -62,7 +62,6 @@ func (n *nodeState) String() string {
 		spew.Sdump(n.node), n.runningJob, n.runningTask, n.snapshotId, n.timeLost, n.timeFlaky, (n.readyCh == nil))
 }
 
-
 // This node was either reported lost by a NodeUpdate and we keep it around for a bit in case it revives,
 // or it experienced connection related errors so we sideline it for a little while.
 func (ns *nodeState) suspended() bool {

--- a/snapshot/bazel/checkouter.go
+++ b/snapshot/bazel/checkouter.go
@@ -23,11 +23,7 @@ func (bf *BzFiler) CheckoutAt(id string, dir string) (snapshot.Checkout, error) 
 	if err != nil {
 		return nil, err
 	}
-	sha, err := bazel.GetSha(id)
-	if err != nil {
-		return nil, err
-	}
-	size, err := bazel.GetSize(id)
+	sha, size, err := bazel.GetShaAndSize(id)
 	if err != nil {
 		return nil, err
 	}

--- a/snapshot/bazel/filer_test.go
+++ b/snapshot/bazel/filer_test.go
@@ -236,54 +236,6 @@ func TestValidateIdInvalid(t *testing.T) {
 	}
 }
 
-func TestGetSha(t *testing.T) {
-	size := int64(5)
-	id := bazel.SnapshotID(emptySha, size)
-	result, err := bazel.GetSha(id)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result != emptySha {
-		t.Fatalf("Expected %s, got %s", emptySha, result)
-	}
-}
-
-func TestGetSize(t *testing.T) {
-	size := int64(5)
-	id := bazel.SnapshotID(emptySha, size)
-	result, err := bazel.GetSize(id)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result != size {
-		t.Fatalf("Expected %d, got %d", size, result)
-	}
-}
-
-func TestSplitIdValid(t *testing.T) {
-	size := int64(5)
-	id := bazel.SnapshotID(emptySha, size)
-	result, err := bazel.SplitID(id)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := []string{bazel.SnapshotIDPrefix, emptySha, "5"}
-	for idx, _ := range result {
-		if result[idx] != expected[idx] {
-			t.Fatalf("Expected %v, received %v", expected, result)
-		}
-	}
-}
-
-func TestSplitIdInvalid(t *testing.T) {
-	size := int64(5)
-	id := fmt.Sprintf("bs-%s-%d", emptySha, size)
-	_, err := bazel.SplitID(id)
-	if err == nil || !strings.Contains(err.Error(), bazel.InvalidIDMsg) {
-		t.Fatalf("Expected error to contain \"%s\", received \"%v\"", bazel.InvalidIDMsg, err)
-	}
-}
-
 func TestValidateFsUtilSaveOutput(t *testing.T) {
 	s := fmt.Sprintf("\n\t%s %d\n", emptySha, int64(32))
 	err := validateFsUtilSaveOutput([]byte(s))

--- a/snapshot/bazel/fs_util_test.go
+++ b/snapshot/bazel/fs_util_test.go
@@ -79,19 +79,15 @@ func TestSaveDir(t *testing.T) {
 	if id == emptyID {
 		t.Fatalf("Expected id to not be %s, was %s", emptyID, id)
 	}
-	size, err := bazel.GetSize(id)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if size <= emptySize {
-		t.Fatalf("Expected size to be >%d, ID: %s", emptySize, id)
-	}
-	sha, err := bazel.GetSha(id)
+	sha, size, err := bazel.GetShaAndSize(id)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if sha == emptySha {
 		t.Fatalf("Expected sha to not be %s. ID: %s", emptySha, id)
+	}
+	if size <= emptySize {
+		t.Fatalf("Expected size to be >%d, ID: %s", emptySize, id)
 	}
 }
 
@@ -142,21 +138,16 @@ func TestSaveFile(t *testing.T) {
 	if id == emptyID {
 		t.Fatalf("Expected id to not be %s, was %s", id, emptyID)
 	}
-	size, err := bazel.GetSize(id)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if size <= emptySize {
-		t.Fatalf("Expected size to be >%d, ID: %s", emptySize, id)
-	}
-	sha, err := bazel.GetSha(id)
+	sha, size, err := bazel.GetShaAndSize(id)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if sha == emptySha {
 		t.Fatalf("Expected sha to not be %s. ID: %s", emptySha, id)
 	}
-
+	if size <= emptySize {
+		t.Fatalf("Expected size to be >%d, ID: %s", emptySize, id)
+	}
 }
 
 // directory materialize test


### PR DESCRIPTION
* some minor reorgs.

Added some split post-process ingestion for the Invoker, based on RunType. For Commands that are invoked that are of RunTypeBazel, we ingest output Bazel-style (according to the API). This means:
* stdout and stderr uploaded to CAS directly
* OutputFiles/Dirs are specified in the ExecuteRequest data. We scan the checkout dir after Argv is run and upload these to CAS (via BzFiler.Ingest) if found.
* Bazel Digests (functioning as lookup keys for the data in the CAS) for stdout, stderr, and any Ingested outputs are returned in the runner.Status's ActionResult field

* Some end to end testing is pending based on fs_util's ability to upload to CAS, but this is non-blocking