### PR TITLE
bazel - use ActionCache when running bazel tasks

### DIFF
--- a/bazel/cas/client.go
+++ b/bazel/cas/client.go
@@ -181,6 +181,13 @@ func getCacheFromClient(acc remoteexecution.ActionCacheClient,
 
 	ar, err := acc.GetActionResult(context.Background(), req)
 	if err != nil {
+		// If error is a grpc Status, check if it has a grpc NOT_FOUND code
+		if grpcStatus, ok := status.FromError(err); ok {
+			if grpcStatus.Code() == codes.NotFound {
+				return nil, &NotFoundError{Err: grpcStatus.Message()}
+			}
+		}
+		return nil, fmt.Errorf("Failed Recv'ing data from server: %s", err)
 		return nil, fmt.Errorf("Failed to make GetActionResult request: %s", err)
 	}
 

--- a/bazel/cas/client.go
+++ b/bazel/cas/client.go
@@ -153,3 +153,70 @@ func writeFromClient(bsc bytestream.ByteStreamClient, req *bytestream.WriteReque
 
 	return nil
 }
+
+// Client function for GetActionResult requests. Takes a Resolver for ActionCache server and Digest to get.
+func GetCacheResult(r dialer.Resolver, digest *remoteexecution.Digest) (*remoteexecution.ActionResult, error) {
+	serverAddr, err := r.Resolve()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to resolve server address: %s", err)
+	}
+
+	cc, err := grpc.Dial(serverAddr, grpc.WithInsecure())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to dial server %s: %s", serverAddr, err)
+	}
+	defer cc.Close()
+
+	req := &remoteexecution.GetActionResultRequest{ActionDigest: digest}
+
+	acc := remoteexecution.NewActionCacheClient(cc)
+	return getCacheFromClient(acc, req)
+}
+
+func getCacheFromClient(acc remoteexecution.ActionCacheClient,
+	req *remoteexecution.GetActionResultRequest) (*remoteexecution.ActionResult, error) {
+	if req == nil {
+		return nil, fmt.Errorf("Unexpected nil GetActionResultRequest in client")
+	}
+
+	ar, err := acc.GetActionResult(context.Background(), req)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to make GetActionResult request: %s", err)
+	}
+
+	return ar, nil
+}
+
+// Client function for UpdateActionResult requests. Takes a Resolver for ActionCache server and Digest/ActionResult to update.
+func UpdateCacheResult(r dialer.Resolver,
+	digest *remoteexecution.Digest, ar *remoteexecution.ActionResult) (*remoteexecution.ActionResult, error) {
+	serverAddr, err := r.Resolve()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to resolve server address: %s", err)
+	}
+
+	cc, err := grpc.Dial(serverAddr, grpc.WithInsecure())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to dial server %s: %s", serverAddr, err)
+	}
+	defer cc.Close()
+
+	req := &remoteexecution.UpdateActionResultRequest{ActionDigest: digest, ActionResult: ar}
+
+	acc := remoteexecution.NewActionCacheClient(cc)
+	return updateCacheFromClient(acc, req)
+}
+
+func updateCacheFromClient(acc remoteexecution.ActionCacheClient,
+	req *remoteexecution.UpdateActionResultRequest) (*remoteexecution.ActionResult, error) {
+	if req == nil {
+		return nil, fmt.Errorf("Unexpected nil UpdateActionResultRequest in client")
+	}
+
+	ar, err := acc.UpdateActionResult(context.Background(), req)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to make UpdateActionResult request: %s", err)
+	}
+
+	return ar, nil
+}

--- a/bazel/cas/client.go
+++ b/bazel/cas/client.go
@@ -187,7 +187,6 @@ func getCacheFromClient(acc remoteexecution.ActionCacheClient,
 				return nil, &NotFoundError{Err: grpcStatus.Message()}
 			}
 		}
-		return nil, fmt.Errorf("Failed Recv'ing data from server: %s", err)
 		return nil, fmt.Errorf("Failed to make GetActionResult request: %s", err)
 	}
 

--- a/bazel/execution/bazelapi/bazel.thrift
+++ b/bazel/execution/bazelapi/bazel.thrift
@@ -56,6 +56,7 @@ struct OutputDirectory {
 # Modeled after https://godoc.org/google.golang.org/genproto/googleapis/devtools/remoteexecution/v1test#ActionResult
 # Added Digest field for passing around actionDigest
 # Added GRPCStatus field for passing a googleapis rpc status value as protobuf-serialized bytes
+# Added cached field for signaling whether the result was retrieved from ActionCache and not executed
 struct ActionResult {
   1: optional Digest stdoutDigest
   2: optional Digest stderrDigest
@@ -66,4 +67,5 @@ struct ActionResult {
   7: optional i32 exitCode
   8: optional Digest actionDigest
   9: optional binary GRPCStatus
+  10: optional bool cached
 }

--- a/bazel/execution/bazelapi/definitions.go
+++ b/bazel/execution/bazelapi/definitions.go
@@ -32,6 +32,7 @@ type ActionResult struct {
 	Result       *remoteexecution.ActionResult
 	ActionDigest *remoteexecution.Digest
 	GRPCStatus   *google_rpc_status.Status
+	Cached       bool
 }
 
 func (e *ExecuteRequest) String() string {
@@ -83,6 +84,13 @@ func (a *ActionResult) GetGRPCStatus() *google_rpc_status.Status {
 	return a.GRPCStatus
 }
 
+func (a *ActionResult) GetCached() bool {
+	if a == nil {
+		return false
+	}
+	return a.Cached
+}
+
 // Transform request Bazel ExecuteRequest data into a domain object
 func MakeExecReqDomainFromThrift(thriftRequest *bazelthrift.ExecuteRequest) *ExecuteRequest {
 	if thriftRequest == nil {
@@ -131,6 +139,7 @@ func MakeActionResultDomainFromThrift(thriftResult *bazelthrift.ActionResult_) *
 		Result:       ar,
 		ActionDigest: makeDigestFromThrift(thriftResult.GetActionDigest()),
 		GRPCStatus:   makeGRPCStatusFromThrift(thriftResult.GetGRPCStatus()),
+		Cached:       thriftResult.GetCached(),
 	}
 }
 
@@ -141,6 +150,7 @@ func MakeActionResultThriftFromDomain(actionResult *ActionResult) *bazelthrift.A
 		return nil
 	}
 	var ec int32 = actionResult.Result.GetExitCode()
+	var cached bool = actionResult.GetCached()
 	return &bazelthrift.ActionResult_{
 		StdoutDigest:      makeDigestThriftFromDomain(actionResult.Result.GetStdoutDigest()),
 		StderrDigest:      makeDigestThriftFromDomain(actionResult.Result.GetStderrDigest()),
@@ -151,6 +161,7 @@ func MakeActionResultThriftFromDomain(actionResult *ActionResult) *bazelthrift.A
 		ExitCode:          &ec,
 		ActionDigest:      makeDigestThriftFromDomain(actionResult.ActionDigest),
 		GRPCStatus:        makeGRPCStatusThriftFromDomain(actionResult.GRPCStatus),
+		Cached:            &cached,
 	}
 }
 

--- a/bazel/execution/bazelapi/gen-go/bazel/ttypes.go
+++ b/bazel/execution/bazelapi/gen-go/bazel/ttypes.go
@@ -1371,6 +1371,7 @@ func (p *OutputDirectory) String() string {
 //  - ExitCode
 //  - ActionDigest
 //  - GRPCStatus
+//  - Cached
 type ActionResult_ struct {
 	StdoutDigest      *Digest            `thrift:"stdoutDigest,1" json:"stdoutDigest,omitempty"`
 	StderrDigest      *Digest            `thrift:"stderrDigest,2" json:"stderrDigest,omitempty"`
@@ -1381,6 +1382,7 @@ type ActionResult_ struct {
 	ExitCode          *int32             `thrift:"exitCode,7" json:"exitCode,omitempty"`
 	ActionDigest      *Digest            `thrift:"actionDigest,8" json:"actionDigest,omitempty"`
 	GRPCStatus        []byte             `thrift:"GRPCStatus,9" json:"GRPCStatus,omitempty"`
+	Cached            *bool              `thrift:"cached,10" json:"cached,omitempty"`
 }
 
 func NewActionResult_() *ActionResult_ {
@@ -1452,6 +1454,15 @@ var ActionResult__GRPCStatus_DEFAULT []byte
 func (p *ActionResult_) GetGRPCStatus() []byte {
 	return p.GRPCStatus
 }
+
+var ActionResult__Cached_DEFAULT bool
+
+func (p *ActionResult_) GetCached() bool {
+	if !p.IsSetCached() {
+		return ActionResult__Cached_DEFAULT
+	}
+	return *p.Cached
+}
 func (p *ActionResult_) IsSetStdoutDigest() bool {
 	return p.StdoutDigest != nil
 }
@@ -1486,6 +1497,10 @@ func (p *ActionResult_) IsSetActionDigest() bool {
 
 func (p *ActionResult_) IsSetGRPCStatus() bool {
 	return p.GRPCStatus != nil
+}
+
+func (p *ActionResult_) IsSetCached() bool {
+	return p.Cached != nil
 }
 
 func (p *ActionResult_) Read(iprot thrift.TProtocol) error {
@@ -1536,6 +1551,10 @@ func (p *ActionResult_) Read(iprot thrift.TProtocol) error {
 			}
 		case 9:
 			if err := p.readField9(iprot); err != nil {
+				return err
+			}
+		case 10:
+			if err := p.readField10(iprot); err != nil {
 				return err
 			}
 		default:
@@ -1653,6 +1672,15 @@ func (p *ActionResult_) readField9(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *ActionResult_) readField10(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBool(); err != nil {
+		return thrift.PrependError("error reading field 10: ", err)
+	} else {
+		p.Cached = &v
+	}
+	return nil
+}
+
 func (p *ActionResult_) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("ActionResult"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -1682,6 +1710,9 @@ func (p *ActionResult_) Write(oprot thrift.TProtocol) error {
 		return err
 	}
 	if err := p.writeField9(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField10(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -1839,6 +1870,21 @@ func (p *ActionResult_) writeField9(oprot thrift.TProtocol) (err error) {
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T write field end error 9:GRPCStatus: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *ActionResult_) writeField10(oprot thrift.TProtocol) (err error) {
+	if p.IsSetCached() {
+		if err := oprot.WriteFieldBegin("cached", thrift.BOOL, 10); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 10:cached: ", p), err)
+		}
+		if err := oprot.WriteBool(bool(*p.Cached)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.cached (10) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 10:cached: ", p), err)
 		}
 	}
 	return err

--- a/bazel/execution/service.go
+++ b/bazel/execution/service.go
@@ -177,7 +177,7 @@ func (s *executionServer) GetOperation(
 		}
 		res := &remoteexecution.ExecuteResponse{
 			Result:       actionResult.GetResult(),
-			CachedResult: false,
+			CachedResult: actionResult.GetCached(),
 			Status:       grpcs,
 		}
 		resAsPBAny, err := marshalAny(res)

--- a/get_fs_util.sh
+++ b/get_fs_util.sh
@@ -2,7 +2,7 @@
 # Pulls in fs_util tool for use in remote exec ingestion, checkout, and CAS ops
 set -e
 
-pants_release="1.5.0rc0%2Bb5c5b7ee"
+pants_release="1.6.0.dev0%2B32de7edf"
 
 get_fs_util() {
 	case "$(uname -s)" in

--- a/runner/runners/bazel.go
+++ b/runner/runners/bazel.go
@@ -44,7 +44,8 @@ func preProcessBazel(filer snapshot.Filer, cmd *runner.Command) (*bazelapi.Actio
 		log.Info("Checking for existing results for command in ActionCache")
 		ar, err := cas.GetCacheResult(bzFiler.CASResolver, cmd.ExecuteRequest.GetActionDigest())
 		if err != nil {
-			// Only treat as an error if we didn't get NotFoundError
+			// Only treat as an error if we didn't get NotFoundError. We still continue:
+			// cache lookup failure is internal, and should not prevent the run
 			if _, ok := err.(*cas.NotFoundError); !ok {
 				log.Errorf("Failed to check for cached result, will execute: %s", err)
 			}

--- a/runner/runners/bazel.go
+++ b/runner/runners/bazel.go
@@ -48,13 +48,14 @@ func preProcessBazel(filer snapshot.Filer, cmd *runner.Command) (*bazelapi.Actio
 			if _, ok := err.(*cas.NotFoundError); !ok {
 				log.Errorf("Failed to check for cached result, will execute: %s", err)
 			}
+		} else if ar != nil {
+			log.Info("Returning cached result for command")
+			return &bazelapi.ActionResult{
+				Result:       ar,
+				ActionDigest: cmd.ExecuteRequest.GetActionDigest(),
+				Cached:       true,
+			}, nil
 		}
-
-		return &bazelapi.ActionResult{
-			Result:       ar,
-			ActionDigest: cmd.ExecuteRequest.GetActionDigest(),
-			Cached:       true,
-		}, nil
 	}
 
 	if err := fetchBazelCommand(bzFiler, cmd); err != nil {


### PR DESCRIPTION
* Add UpdateActionResult implementation
* Add client functions for ActionCache
* Add Cached field to domain ActionResult to be able to show client if result was cached
* When running bazel task, check cache for result
* When completing bazel task, upload result to cache
* Respect optional cache/skipcache settings