### PR TITLE
integration test - move to standalone binary to avoid deadlocking unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,11 @@ recoverytest:
 	go install ./binaries/...
 	$(FIRSTGOPATH)/bin/recoverytest &>/dev/null
 
+integrationtest:
+	# Integration test with some overlap with other standalone tests, but utilizes client binaries
+	go install ./binaries/...
+	$(FIRSTGOPATH)/bin/scoot-integration &>/dev/null
+
 clean-mockgen:
 	rm */*_mock.go
 
@@ -101,7 +106,7 @@ clean: clean-data clean-mockgen clean-go
 
 fullbuild: dependencies generate test
 
-travis: dependencies fs_util recoverytest swarmtest test clean-data
+travis: dependencies fs_util recoverytest swarmtest integrationtest test clean-data
 
 thrift-worker-go:
 	# Create generated code in github.com/twitter/scoot/workerapi/gen-go/... from worker.thrift

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -1,3 +1,0 @@
-// Placeholder file to allow for building of tests package in TravisCI
-// due to https://golang.org/pkg/go/build/#hdr-Build_Constraints
-package tests


### PR DESCRIPTION
Just moving tests/integration_test to an independent binary, a la recoverytest.

I could not consistently repro this, but the test running in-line caused me to have to manually kill a go test and zombied scoot binary procs at least half a dozen times.

Have to say I find myself not particularly fond of the Twitter OSS PR template.