### PR TITLE
sched/stateful_scheduler - don't check for node readded if node absent

### DIFF
--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -838,7 +838,10 @@ func (s *statefulScheduler) scheduleTasks() {
 				nodeId := nodeSt.node.Id()
 				nodeStInstance, ok := s.clusterState.getNodeState(nodeId)
 				nodeAbsent := !ok
-				nodeReAdded := &nodeStInstance.readyCh != &nodeSt.readyCh
+				nodeReAdded := false
+				if !nodeAbsent {
+					nodeReAdded = &nodeStInstance.readyCh != &nodeSt.readyCh
+				}
 				nodeStChanged := nodeAbsent || nodeReAdded
 				preempted := false
 

--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -840,7 +840,7 @@ func (s *statefulScheduler) scheduleTasks() {
 				nodeAbsent := !ok
 				nodeReAdded := false
 				if !nodeAbsent {
-					nodeReAdded = &nodeStInstance.readyCh != &nodeSt.readyCh
+					nodeReAdded = (&nodeStInstance.readyCh != &nodeSt.readyCh)
 				}
 				nodeStChanged := nodeAbsent || nodeReAdded
 				preempted := false


### PR DESCRIPTION
Created a frequent panic in staging env.