### PR TITLE
bazel/thrift - leave digest as nil when making thrift from domain digest

### DIFF
--- a/bazel/execution/bazelapi/definitions.go
+++ b/bazel/execution/bazelapi/definitions.go
@@ -272,7 +272,7 @@ func makeActionThriftFromDomain(action *remoteexecution.Action) *bazelthrift.Act
 
 func makeDigestThriftFromDomain(digest *remoteexecution.Digest) *bazelthrift.Digest {
 	if digest == nil {
-		return &bazelthrift.Digest{}
+		return nil
 	}
 	var hash string = digest.GetHash()
 	var size int64 = digest.GetSizeBytes()


### PR DESCRIPTION
Fixes #372 

This was probably done "defensively," but tested fine against a variety of bazel api scenarios.