### PR TITLE
bzutil: add --json flag to execute and getOperation

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -48,7 +48,7 @@ The worflow will be:
 1. Start up a scheduler, apiserver, and workerserver
 2. Upload the request Command (argv and env) to the apiserver via the CAS API
 3. Upload the request input directory to the apiserver via fs_util/CAS API
-5. Upload the request Action (references Command and input) to the apiserver via the CAS API
+4. Upload the request Action (references Command and input) to the apiserver via the CAS API
 5. Schedule the request on the scheduler via the Execution API
 6. Get results of the request from the scheduler via the Longrunning API
 
@@ -75,7 +75,7 @@ fs_util --local-store-path=/Users/$USER/workspace/bazel/db --server-address=loca
 
 4:
 ```sh
-bzutil upload_action -cas_addr=localhost:12100 -command="1833d7c57656d2b7ee97e2068ce742f80e61357fba12a8b8d627782da3a58c29/11" -input_root="89a9068bd2d2784d5379b9fa3d02f02d9d0d7ecf4998a8e45b3d6784aacad4d4/157"
+bzutil upload_action --cas_addr=localhost:12100 --command="1833d7c57656d2b7ee97e2068ce742f80e61357fba12a8b8d627782da3a58c29/11" --input_root="89a9068bd2d2784d5379b9fa3d02f02d9d0d7ecf4998a8e45b3d6784aacad4d4/157"
 INFO[0000] Wrote to CAS successfully                     sourceLine="bzutil/main.go:220"
 0cb08d1ec25eeed4d7a10d8a2cce85ea7810b76cfd43926e305288b19cf9aa3c/141
 ```

--- a/binaries/bzutil/main.go
+++ b/binaries/bzutil/main.go
@@ -234,6 +234,7 @@ func execute(execAddr, actionDigestStr string, skipCache bool) {
 		log.Fatalf("Error making Execute request: %s", err)
 	}
 	log.Info(execution.ExecuteOperationToStr(operation))
+	fmt.Printf("%s", operation.GetName())
 }
 
 func getOperation(execAddr, opName string) {
@@ -244,6 +245,7 @@ func getOperation(execAddr, opName string) {
 	}
 
 	log.Info(execution.ExecuteOperationToStr(operation))
+	fmt.Printf(operation.GetDone())
 }
 
 func printSupported() {

--- a/binaries/bzutil/main.go
+++ b/binaries/bzutil/main.go
@@ -74,7 +74,7 @@ func main() {
 	getCommand := flag.NewFlagSet(getOpCmdStr, flag.ExitOnError)
 	getAddr := getCommand.String("grpc_addr", scootapi.DefaultSched_GRPC, "'host:port' of grpc Exec server")
 	getName := getCommand.String("name", "", "Operation name to query")
-	getJson := execCommand.Bool("json", false, "Print operation as JSON")
+	getJson := getCommand.Bool("json", false, "Print operation as JSON")
 
 	// Parse input flags
 	if len(os.Args) < 2 {


### PR DESCRIPTION
Problem

Clients who are polling the scheduler for their operation's status are passed unstructured data through an Info level log in stderr

Solution

Add --json flags to execute & getOperation

Result

When --json is passed, marshaled operation structs will print to stdout
