### PR TITLE
bzutil: json for upload_action & upload_command digests

### DIFF
--- a/bazel/digest.go
+++ b/bazel/digest.go
@@ -38,3 +38,10 @@ func DigestFromString(s string) (*remoteexecution.Digest, error) {
 	}
 	return DigestFromSnapshotID(snap)
 }
+
+func DigestToStr(d *remoteexecution.Digest) string {
+	if d == nil || d.GetHash() == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/%d", d.GetHash(), d.GetSizeBytes())
+}

--- a/bazel/execution/client.go
+++ b/bazel/execution/client.go
@@ -12,6 +12,7 @@ import (
 	google_rpc_code "google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/grpc"
 
+	"github.com/twitter/scoot/bazel"
 	"github.com/twitter/scoot/common/dialer"
 	"github.com/twitter/scoot/common/proto"
 )
@@ -125,7 +126,7 @@ func ExecuteOperationToStr(op *longrunning.Operation) string {
 	s := fmt.Sprintf("Operation: %s\n\tDone: %t\n", op.GetName(), op.GetDone())
 	s += fmt.Sprintf("\tMetadata:\n")
 	s += fmt.Sprintf("\t\tStage: %s\n", eom.GetStage())
-	s += fmt.Sprintf("\t\tActionDigest: %s\n", DigestToStr(eom.GetActionDigest()))
+	s += fmt.Sprintf("\t\tActionDigest: %s\n", bazel.DigestToStr(eom.GetActionDigest()))
 	if res != nil {
 		s += fmt.Sprintf("\tExecResponse:\n")
 		s += fmt.Sprintf("\t\tStatus: %s\n", res.GetStatus())
@@ -135,8 +136,8 @@ func ExecuteOperationToStr(op *longrunning.Operation) string {
 		s += fmt.Sprintf("\t\t\tExitCode: %d\n", res.GetResult().GetExitCode())
 		s += fmt.Sprintf("\t\t\tOutputFiles: %s\n", res.GetResult().GetOutputFiles())
 		s += fmt.Sprintf("\t\t\tOutputDirectories: %s\n", res.GetResult().GetOutputDirectories())
-		s += fmt.Sprintf("\t\t\tStdoutDigest: %s\n", DigestToStr(res.GetResult().GetStdoutDigest()))
-		s += fmt.Sprintf("\t\t\tStderrDigest: %s\n", DigestToStr(res.GetResult().GetStderrDigest()))
+		s += fmt.Sprintf("\t\t\tStdoutDigest: %s\n", bazel.DigestToStr(res.GetResult().GetStdoutDigest()))
+		s += fmt.Sprintf("\t\t\tStderrDigest: %s\n", bazel.DigestToStr(res.GetResult().GetStderrDigest()))
 		if res.GetResult().GetExecutionMetadata() != nil {
 			em := res.GetResult().GetExecutionMetadata()
 			s += fmt.Sprintf("\t\t\tExecutionMetadata:\n")
@@ -149,13 +150,6 @@ func ExecuteOperationToStr(op *longrunning.Operation) string {
 		}
 	}
 	return s
-}
-
-func DigestToStr(d *remoteexecution.Digest) string {
-	if d == nil || d.GetHash() == "" {
-		return ""
-	}
-	return fmt.Sprintf("%s/%d", d.GetHash(), d.GetSizeBytes())
 }
 
 func addLatencyToStr(inputStr, indent, label string, startTs, endTs *timestamp.Timestamp) string {

--- a/bazel/execution/client.go
+++ b/bazel/execution/client.go
@@ -125,7 +125,7 @@ func ExecuteOperationToStr(op *longrunning.Operation) string {
 	s := fmt.Sprintf("Operation: %s\n\tDone: %t\n", op.GetName(), op.GetDone())
 	s += fmt.Sprintf("\tMetadata:\n")
 	s += fmt.Sprintf("\t\tStage: %s\n", eom.GetStage())
-	s += fmt.Sprintf("\t\tActionDigest: %s\n", digestToStr(eom.GetActionDigest()))
+	s += fmt.Sprintf("\t\tActionDigest: %s\n", DigestToStr(eom.GetActionDigest()))
 	if res != nil {
 		s += fmt.Sprintf("\tExecResponse:\n")
 		s += fmt.Sprintf("\t\tStatus: %s\n", res.GetStatus())
@@ -135,8 +135,8 @@ func ExecuteOperationToStr(op *longrunning.Operation) string {
 		s += fmt.Sprintf("\t\t\tExitCode: %d\n", res.GetResult().GetExitCode())
 		s += fmt.Sprintf("\t\t\tOutputFiles: %s\n", res.GetResult().GetOutputFiles())
 		s += fmt.Sprintf("\t\t\tOutputDirectories: %s\n", res.GetResult().GetOutputDirectories())
-		s += fmt.Sprintf("\t\t\tStdoutDigest: %s\n", digestToStr(res.GetResult().GetStdoutDigest()))
-		s += fmt.Sprintf("\t\t\tStderrDigest: %s\n", digestToStr(res.GetResult().GetStderrDigest()))
+		s += fmt.Sprintf("\t\t\tStdoutDigest: %s\n", DigestToStr(res.GetResult().GetStdoutDigest()))
+		s += fmt.Sprintf("\t\t\tStderrDigest: %s\n", DigestToStr(res.GetResult().GetStderrDigest()))
 		if res.GetResult().GetExecutionMetadata() != nil {
 			em := res.GetResult().GetExecutionMetadata()
 			s += fmt.Sprintf("\t\t\tExecutionMetadata:\n")
@@ -151,7 +151,7 @@ func ExecuteOperationToStr(op *longrunning.Operation) string {
 	return s
 }
 
-func digestToStr(d *remoteexecution.Digest) string {
+func DigestToStr(d *remoteexecution.Digest) string {
 	if d == nil || d.GetHash() == "" {
 		return ""
 	}

--- a/binaries/bzutil/main.go
+++ b/binaries/bzutil/main.go
@@ -185,7 +185,7 @@ func uploadBzCommand(cmdArgs []string, casAddr, env, outputFilesStr, outputDirsS
 	}
 
 	log.Info("Wrote to CAS successfully")
-	log.Info(execution.DigestToStr(digest))
+	log.Info(bazel.DigestToStr(digest))
 	if uploadJson {
 		b, err := json.Marshal(digest)
 		if err != nil {
@@ -230,7 +230,7 @@ func uploadBzAction(casAddr, commandDigestStr, rootDigestStr string, noCache, ac
 	}
 
 	log.Info("Wrote to CAS successfully")
-	log.Info(execution.DigestToStr(digest))
+	log.Info(bazel.DigestToStr(digest))
 	if actionJson {
 		b, err := json.Marshal(digest)
 		if err != nil {

--- a/binaries/bzutil/main.go
+++ b/binaries/bzutil/main.go
@@ -55,7 +55,7 @@ func main() {
 	uploadEnv := uploadCommand.String("env", "", "comma-separated command environment variables, i.e. \"key1=val1,key2=val2\"")
 	uploadOutputFiles := uploadCommand.String("output_files", "", "Output files to ingest as comma-separated list: '/file1,/dir/file2'")
 	uploadOutputDirs := uploadCommand.String("output_dirs", "", "Output dirs to ingest as comma-separated list: '/dir'")
-	uploadJson := uploadCommand.Bool("json", false, "Print command as JSON")
+	uploadJson := uploadCommand.Bool("json", false, "Print command digest as JSON")
 
 	// Upload Action
 	uploadAction := flag.NewFlagSet(uploadActionStr, flag.ExitOnError)
@@ -63,7 +63,7 @@ func main() {
 	actionCommandDigest := uploadAction.String("command", "", "Command digest as '<hash>/<size>'")
 	actionRootDigest := uploadAction.String("input_root", "", "Input root digest as '<hash>/<size>'")
 	actionNoCache := uploadAction.Bool("no_cache", false, "Flag to prevent result caching")
-	actionJson := uploadAction.Bool("json", false, "Print action as JSON")
+	actionJson := uploadAction.Bool("json", false, "Print action digest as JSON")
 
 	// Execute
 	execCommand := flag.NewFlagSet(execCmdStr, flag.ExitOnError)

--- a/binaries/bzutil/main.go
+++ b/binaries/bzutil/main.go
@@ -55,6 +55,7 @@ func main() {
 	uploadEnv := uploadCommand.String("env", "", "comma-separated command environment variables, i.e. \"key1=val1,key2=val2\"")
 	uploadOutputFiles := uploadCommand.String("output_files", "", "Output files to ingest as comma-separated list: '/file1,/dir/file2'")
 	uploadOutputDirs := uploadCommand.String("output_dirs", "", "Output dirs to ingest as comma-separated list: '/dir'")
+	uploadJson := uploadCommand.Bool("json", false, "Print command as JSON")
 
 	// Upload Action
 	uploadAction := flag.NewFlagSet(uploadActionStr, flag.ExitOnError)
@@ -62,6 +63,7 @@ func main() {
 	actionCommandDigest := uploadAction.String("command", "", "Command digest as '<hash>/<size>'")
 	actionRootDigest := uploadAction.String("input_root", "", "Input root digest as '<hash>/<size>'")
 	actionNoCache := uploadAction.Bool("no_cache", false, "Flag to prevent result caching")
+	actionJson := uploadAction.Bool("json", false, "Print action as JSON")
 
 	// Execute
 	execCommand := flag.NewFlagSet(execCmdStr, flag.ExitOnError)
@@ -101,12 +103,12 @@ func main() {
 		if len(uploadArgv) == 0 {
 			log.Fatalf("Argv required for %s - will interpret all non-flag arguments as Argv", uploadCmdStr)
 		}
-		uploadBzCommand(uploadArgv, *uploadAddr, *uploadEnv, *uploadOutputFiles, *uploadOutputDirs)
+		uploadBzCommand(uploadArgv, *uploadAddr, *uploadEnv, *uploadOutputFiles, *uploadOutputDirs, *uploadJson)
 	} else if uploadAction.Parsed() {
 		if *actionCommandDigest == "" || *actionRootDigest == "" {
 			log.Fatalf("command and input_root required for %s", execCmdStr)
 		}
-		uploadBzAction(*actionAddr, *actionCommandDigest, *actionRootDigest, *actionNoCache)
+		uploadBzAction(*actionAddr, *actionCommandDigest, *actionRootDigest, *actionNoCache, *actionJson)
 	} else if execCommand.Parsed() {
 		if *execActionDigest == "" {
 			log.Fatalf("action digest required for %s", execCmdStr)
@@ -122,7 +124,7 @@ func main() {
 	}
 }
 
-func uploadBzCommand(cmdArgs []string, casAddr, env, outputFilesStr, outputDirsStr string) {
+func uploadBzCommand(cmdArgs []string, casAddr, env, outputFilesStr, outputDirsStr string, uploadJson bool) {
 	envMap := make(map[string]string)
 	for _, pair := range strings.Split(env, ",") {
 		if pair == "" {
@@ -183,10 +185,17 @@ func uploadBzCommand(cmdArgs []string, casAddr, env, outputFilesStr, outputDirsS
 	}
 
 	log.Info("Wrote to CAS successfully")
-	fmt.Printf("%s/%d\n", hash, size)
+	log.Info(execution.DigestToStr(digest))
+	if uploadJson {
+		b, err := json.Marshal(digest)
+		if err != nil {
+			log.Fatalf("Error converting digest to JSON: %v", err)
+		}
+		fmt.Printf("%s\n", b)
+	}
 }
 
-func uploadBzAction(casAddr, commandDigestStr, rootDigestStr string, noCache bool) {
+func uploadBzAction(casAddr, commandDigestStr, rootDigestStr string, noCache, actionJson bool) {
 	commandDigest, err := bazel.DigestFromString(commandDigestStr)
 	if err != nil {
 		log.Fatalf("Error converting action to Digest: %s", err)
@@ -221,7 +230,14 @@ func uploadBzAction(casAddr, commandDigestStr, rootDigestStr string, noCache boo
 	}
 
 	log.Info("Wrote to CAS successfully")
-	fmt.Printf("%s/%d\n", hash, size)
+	log.Info(execution.DigestToStr(digest))
+	if actionJson {
+		b, err := json.Marshal(digest)
+		if err != nil {
+			log.Fatalf("Error converting digest to JSON: %v", err)
+		}
+		fmt.Printf("%s\n", b)
+	}
 }
 
 func execute(execAddr, actionDigestStr string, skipCache bool, execJson bool) {


### PR DESCRIPTION
Problem

Clients who are upload command & action are passed unstructured data through an Info level log in stderr, which is then needed for later reference when utilizing the execution API

Solution

Add --json flags to upload_action & upload_command

Result

When --json is passed, marshaled digest structs will print to stdout
