### PR TITLE
bazel - add, cleanup baseline metrics

### DIFF
--- a/bazel/cas/service.go
+++ b/bazel/cas/service.go
@@ -83,7 +83,7 @@ func (s *casServer) FindMissingBlobs(
 	defer func() {
 		if err == nil {
 			s.stat.Counter(stats.BzFindBlobsSuccessCounter).Inc(1)
-			s.stat.Gauge(stats.BzFindBlobsLengthGauge).Update(length)
+			s.stat.Histogram(stats.BzFindBlobsLengthHistogram).Update(length)
 		} else {
 			s.stat.Counter(stats.BzFindBlobsFailureCounter).Inc(1)
 		}
@@ -144,7 +144,9 @@ func (s *casServer) Read(req *bytestream.ReadRequest, ser bytestream.ByteStream_
 	defer func() {
 		if err == nil {
 			s.stat.Counter(stats.BzReadSuccessCounter).Inc(1)
-			s.stat.Gauge(stats.BzReadBytesGauge).Update(length)
+			if length > 0 {
+				s.stat.Histogram(stats.BzReadBytesHistogram).Update(length)
+			}
 		} else {
 			s.stat.Counter(stats.BzReadFailureCounter).Inc(1)
 		}
@@ -259,7 +261,9 @@ func (s *casServer) Write(ser bytestream.ByteStream_WriteServer) error {
 	defer func() {
 		if err == nil {
 			s.stat.Counter(stats.BzWriteSuccessCounter).Inc(1)
-			s.stat.Gauge(stats.BzWriteBytesGauge).Update(committed)
+			if committed > 0 {
+				s.stat.Histogram(stats.BzWriteBytesHistogram).Update(committed)
+			}
 		} else {
 			s.stat.Counter(stats.BzWriteFailureCounter).Inc(1)
 		}

--- a/bazel/cas/service.go
+++ b/bazel/cas/service.go
@@ -181,7 +181,10 @@ func (s *casServer) Read(req *bytestream.ReadRequest, ser bytestream.ByteStream_
 		log.Infof("Opening store resource for reading: %s", storeName)
 		r, err = s.storeConfig.Store.OpenForRead(storeName)
 		if err != nil {
-			// Reset err to nil - don't count NotFound towards request failures
+			// If an error occurred opening the underlying resource, we interpret this as NotFound.
+			// Although we return an error response to the caller to indicate this, we regard this
+			// as a normal defined behavior of the API, and don't count it towards failure metrics.
+			// Reset err to nil to prevent recording as a failure.
 			openErr := err
 			err = nil
 			log.Errorf("Failed to OpenForRead: %v", openErr)
@@ -226,6 +229,8 @@ func (s *casServer) Read(req *bytestream.ReadRequest, ser bytestream.ByteStream_
 		if err == nil {
 			continue
 		} else if err == io.EOF {
+			// We expect to hit an EOF, non-nil error condition as the conclusion of a normal read.
+			// Reset err to nil here to prevent recording this as a failure in metrics.
 			err = nil
 			break
 		} else {
@@ -454,7 +459,10 @@ func (s *casServer) GetActionResult(ctx context.Context,
 
 	r, err := s.storeConfig.Store.OpenForRead(address.storeName)
 	if err != nil {
-		// Reset err to nil - don't count NotFound towards request failures
+		// If an error occurred opening the underlying resource, we interpret this as NotFound.
+		// Although we return an error response to the caller to indicate this, we regard this
+		// as a normal defined behavior of the API, and don't count it towards failure metrics.
+		// Reset err to nil to prevent recording as a failure.
 		openErr := err
 		err = nil
 		log.Errorf("Failed to OpenForRead: %v", openErr)

--- a/bazel/cas/service.go
+++ b/bazel/cas/service.go
@@ -75,10 +75,23 @@ func (s *casServer) FindMissingBlobs(
 	if !s.IsInitialized() {
 		return nil, status.Error(codes.Internal, "Server not initialized")
 	}
-	s.stat.Counter(stats.BzFindBlobsRequestCounter).Inc(1)
-	defer s.stat.Latency(stats.BzFindBlobsRequestLatency_ms).Time().Stop()
+
+	var err error = nil
+	var length int64 = 0
+
+	// Record metrics based on final error condition
+	defer func() {
+		if err == nil {
+			s.stat.Counter(stats.BzFindBlobsSuccessCounter).Inc(1)
+			s.stat.Gauge(stats.BzFindBlobsLengthGauge).Update(length)
+		} else {
+			s.stat.Counter(stats.BzFindBlobsFailureCounter).Inc(1)
+		}
+	}()
+	defer s.stat.Latency(stats.BzFindBlobsLatency_ms).Time().Stop()
 
 	res := remoteexecution.FindMissingBlobsResponse{}
+	length = int64(len(req.GetBlobDigests()))
 
 	for _, digest := range req.GetBlobDigests() {
 		// We hardcode support for empty data in snapshot/filer/checkouter.go, so never report it as missing
@@ -123,8 +136,20 @@ func (s *casServer) Read(req *bytestream.ReadRequest, ser bytestream.ByteStream_
 	if !s.IsInitialized() {
 		return status.Error(codes.Internal, "Server not initialized")
 	}
-	s.stat.Counter(stats.BzReadRequestCounter).Inc(1)
-	defer s.stat.Latency(stats.BzReadRequestLatency_ms).Time().Stop()
+
+	var length int64 = 0
+	var err error = nil
+
+	// Record metrics based on final error condition
+	defer func() {
+		if err == nil {
+			s.stat.Counter(stats.BzReadSuccessCounter).Inc(1)
+			s.stat.Gauge(stats.BzReadBytesGauge).Update(length)
+		} else {
+			s.stat.Counter(stats.BzReadFailureCounter).Inc(1)
+		}
+	}()
+	defer s.stat.Latency(stats.BzReadLatency_ms).Time().Stop()
 
 	// Parse resource name per Bazel API specification
 	resource, err := ParseReadResource(req.GetResourceName())
@@ -154,15 +179,17 @@ func (s *casServer) Read(req *bytestream.ReadRequest, ser bytestream.ByteStream_
 		log.Infof("Opening store resource for reading: %s", storeName)
 		r, err = s.storeConfig.Store.OpenForRead(storeName)
 		if err != nil {
-			log.Errorf("Failed to OpenForRead: %v", err)
-			return status.Error(codes.NotFound, fmt.Sprintf("Failed opening resource %s for read, returning NotFound. Err: %v", storeName, err))
+			// Reset err to nil - don't count NotFound towards request failures
+			openErr := err
+			err = nil
+			log.Errorf("Failed to OpenForRead: %v", openErr)
+			return status.Error(codes.NotFound, fmt.Sprintf("Failed opening resource %s for read, returning NotFound. Err: %v", storeName, openErr))
 		}
 	}
 	defer r.Close()
 
 	res := &bytestream.ReadResponse{}
 	c := int64(DefaultReadCapacity)
-	length := int64(0)
 
 	// If ReadOffset was specified, discard bytes prior to it
 	if req.GetReadOffset() > 0 {
@@ -197,6 +224,7 @@ func (s *casServer) Read(req *bytestream.ReadRequest, ser bytestream.ByteStream_
 		if err == nil {
 			continue
 		} else if err == io.EOF {
+			err = nil
 			break
 		} else {
 			log.Errorf("Failed to read from Store: %v", err)
@@ -219,15 +247,24 @@ func (s *casServer) Write(ser bytestream.ByteStream_WriteServer) error {
 	if !s.IsInitialized() {
 		return status.Error(codes.Internal, "Server not initialized")
 	}
-	s.stat.Counter(stats.BzWriteRequestCounter).Inc(1)
-	defer s.stat.Latency(stats.BzWriteRequestLatency_ms).Time().Stop()
 
 	var p []byte
 	var buffer *bytes.Buffer
 	var committed int64 = 0
 	var resource *Resource = nil
 	resourceName, storeName := "", ""
-	var err error
+	var err error = nil
+
+	// Record metrics based on final error condition
+	defer func() {
+		if err == nil {
+			s.stat.Counter(stats.BzWriteSuccessCounter).Inc(1)
+			s.stat.Gauge(stats.BzWriteBytesGauge).Update(committed)
+		} else {
+			s.stat.Counter(stats.BzWriteFailureCounter).Inc(1)
+		}
+	}()
+	defer s.stat.Latency(stats.BzWriteLatency_ms).Time().Stop()
 
 	// As indicated above, not supporting partial/resumable Writes for now.
 	// Reads in a stream of data from the client, and proceeds when we've gotten it all.
@@ -253,7 +290,7 @@ func (s *casServer) Write(ser bytestream.ByteStream_WriteServer) error {
 			if resource.Digest.GetHash() == bazel.EmptySha {
 				log.Infof("Request to write empty sha - bypassing Store write and Closing")
 				res := &bytestream.WriteResponse{CommittedSize: bazel.EmptySize}
-				err := ser.SendAndClose(res)
+				err = ser.SendAndClose(res)
 				if err != nil {
 					log.Errorf("Error during SendAndClose() for EmptySha: %s", err)
 					return status.Error(codes.Internal, fmt.Sprintf("Failed to SendAndClose: %v", err))
@@ -379,8 +416,18 @@ func (s *casServer) GetActionResult(ctx context.Context,
 	if !s.IsInitialized() {
 		return nil, status.Error(codes.Internal, "Server not initialized")
 	}
-	s.stat.Counter(stats.BzGetActionRequestCounter).Inc(1)
-	defer s.stat.Latency(stats.BzGetActionRequestLatency_ms).Time().Stop()
+
+	var err error = nil
+
+	// Record metrics based on final error condition
+	defer func() {
+		if err == nil {
+			s.stat.Counter(stats.BzGetActionSuccessCounter).Inc(1)
+		} else {
+			s.stat.Counter(stats.BzGetActionFailureCounter).Inc(1)
+		}
+	}()
+	defer s.stat.Latency(stats.BzGetActionLatency_ms).Time().Stop()
 
 	// Validate input digest
 	if !bazel.IsValidDigest(req.GetActionDigest().GetHash(), req.GetActionDigest().GetSizeBytes()) {
@@ -403,8 +450,11 @@ func (s *casServer) GetActionResult(ctx context.Context,
 
 	r, err := s.storeConfig.Store.OpenForRead(address.storeName)
 	if err != nil {
-		log.Errorf("Failed to OpenForRead: %v", err)
-		return nil, status.Error(codes.NotFound, fmt.Sprintf("Failed opening %s for read, returning NotFound. Err: %v", address.storeName, err))
+		// Reset err to nil - don't count NotFound towards request failures
+		openErr := err
+		err = nil
+		log.Errorf("Failed to OpenForRead: %v", openErr)
+		return nil, status.Error(codes.NotFound, fmt.Sprintf("Failed opening %s for read, returning NotFound. Err: %v", address.storeName, openErr))
 	}
 	defer r.Close()
 
@@ -416,7 +466,8 @@ func (s *casServer) GetActionResult(ctx context.Context,
 
 	// Deserialize store data as AR
 	ar := &remoteexecution.ActionResult{}
-	if err := proto.Unmarshal(arAsBytes, ar); err != nil {
+	err = proto.Unmarshal(arAsBytes, ar)
+	if err != nil {
 		log.Errorf("Failed to deserialize bytes from %s as ActionResult: %s", address.storeName, err)
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Error deserializing ActionResult: %s", err))
 	}
@@ -434,8 +485,18 @@ func (s *casServer) UpdateActionResult(ctx context.Context,
 	if !s.IsInitialized() {
 		return nil, status.Error(codes.Internal, "Server not initialized")
 	}
-	s.stat.Counter(stats.BzUpdateActionRequestCounter).Inc(1)
-	defer s.stat.Latency(stats.BzUpdateActionRequestLatency_ms).Time().Stop()
+
+	var err error = nil
+
+	// Record metrics based on final error condition
+	defer func() {
+		if err == nil {
+			s.stat.Counter(stats.BzUpdateActionSuccessCounter).Inc(1)
+		} else {
+			s.stat.Counter(stats.BzUpdateActionFailureCounter).Inc(1)
+		}
+	}()
+	defer s.stat.Latency(stats.BzUpdateActionLatency_ms).Time().Stop()
 
 	// Validate input digest, ActionResult
 	if !bazel.IsValidDigest(req.GetActionDigest().GetHash(), req.GetActionDigest().GetSizeBytes()) {

--- a/bazel/execution/service.go
+++ b/bazel/execution/service.go
@@ -76,8 +76,18 @@ func (s *executionServer) Execute(
 	if !s.IsInitialized() {
 		return status.Error(codes.Internal, "Server not initialized")
 	}
-	s.stat.Counter(stats.BzExecRequestCounter).Inc(1)
-	defer s.stat.Latency(stats.BzExecRequestLatency_ms).Time().Stop()
+
+	var err error = nil
+
+	// Record metrics based on final error condition
+	defer func() {
+		if err == nil {
+			s.stat.Counter(stats.BzExecSuccessCounter).Inc(1)
+		} else {
+			s.stat.Counter(stats.BzExecFailureCounter).Inc(1)
+		}
+	}()
+	defer s.stat.Latency(stats.BzExecLatency_ms).Time().Stop()
 
 	// Transform ExecuteRequest into Scoot Job, validate and schedule
 	// If we encounter an error here, assume it was due to an InvalidArgument
@@ -151,8 +161,18 @@ func (s *executionServer) GetOperation(
 	if !s.IsInitialized() {
 		return nil, status.Error(codes.Internal, "Server not initialized")
 	}
-	s.stat.Counter(stats.BzGetOpRequestCounter).Inc(1)
-	defer s.stat.Latency(stats.BzGetOpRequestLatency_ms).Time().Stop()
+
+	var err error = nil
+
+	// Record metrics based on final error condition
+	defer func() {
+		if err == nil {
+			s.stat.Counter(stats.BzGetOpSuccessCounter).Inc(1)
+		} else {
+			s.stat.Counter(stats.BzGetOpFailureCounter).Inc(1)
+		}
+	}()
+	defer s.stat.Latency(stats.BzGetOpLatency_ms).Time().Stop()
 
 	rs, err := s.getRunStatusAndValidate(req.Name)
 	if err != nil {

--- a/common/stats/stats.go
+++ b/common/stats/stats.go
@@ -116,6 +116,9 @@ type StatsReceiver interface {
 	// Add a gauge, which holds a float64 value that can be set arbitrarily.
 	GaugeFloat(name ...string) GaugeFloat
 
+	// Provide a histogram of sampled stats
+	Histogram(name ...string) Histogram
+
 	// Removes the given named stats item if it exists
 	Remove(name ...string)
 

--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -312,11 +312,6 @@ const (
 	SchedPriority2JobsGauge = "priority2JobsGauge"
 
 	/*
-		the number of jobs with priority 3
-	*/
-	SchedPriority3JobsGauge = "priority3JobsGauge"
-
-	/*
 		the number of times the platform retried sending an end saga message
 	*/
 	SchedRetriedEndSagaCounter = "schedRetriedEndSagaCounter"
@@ -383,6 +378,11 @@ const (
 		scheduler's job handling loop.  (No tasks in this job have been started.)
 	*/
 	SchedWaitingJobsGauge = "schedWaitingJobsGauge"
+
+	/*
+		Amount of time it takes the scheduler to complete a full step()
+	*/
+	SchedStepLatency_ms = "schedStepLatency_ms"
 
 	/******************************** Worker metrics **************************************/
 	/*
@@ -588,4 +588,17 @@ const (
 		Amount of time the server takes to process a UpdateActionResult request
 	*/
 	BzUpdateActionRequestLatency_ms = "bzUpdateActionRequestLatency_ms"
+
+	/* TODO
+	- execution tasks number of inputs/outputs. unknown except in snapshot impl!
+		- at checkout time - best we can do is total bytes and elapsed time from fs_util (dl bytes,ms per task)
+		- at upload time - best we can do is total bytes and elapsed time from fs_util (ul bytes,ms per task)
+	- execution metadata timings (record at worker invoker completion)
+		- queued time spent
+		- checkout time - downloadLatency (works for bazel?)
+		- exec time
+		- output upload time - uploadLatency (works for bazel?)
+	- cas read/write byte gauges
+	+ scheduler tick latency
+	*/
 )

--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -516,66 +516,62 @@ const (
 
 	/****************************** Bazel Metrics **********************************************/
 
-	// TODO Gauge values not effective - just getting the last-set value at every metric post/publish interval
-	//	histogram the only effective way of doing this? P-vals like latency calculated & emitted each interval
-	//	probable have to add histogram to stats
-	// TODO Not clear from these what component they are emitted by
 	/****************************** Execution Service ******************************************/
 	/*
-		Execute API metrics
+		Execute API metrics emitted by Scheduler
 	*/
 	BzExecSuccessCounter = "bzExecSuccessCounter"
 	BzExecFailureCounter = "bzExecFailureCounter"
 	BzExecLatency_ms     = "bzExecLatency_ms"
 
 	/*
-		Longrunning GetOperation API metrics
+		Longrunning GetOperation API metrics emitted by Scheduler
 	*/
 	BzGetOpSuccessCounter = "bzGetOpSuccessCounter"
 	BzGetOpFailureCounter = "bzGetOpFailureCounter"
 	BzGetOpLatency_ms     = "bzGetOpLatency_ms"
 
 	/*
-		Execution metadata timing metrics
+		Execution metadata timing metrics emitted by Worker
 	*/
-	BzExecQueuedLatency_ms = "bzExecQueuedLatency_ms"
-	BzExecExecerTime_ms    = "bzExecExecerTime_ms"
+	BzExecQueuedTimeHistogram_ms = "bzExecQueuedTimeHistogram_ms"
+	BzExecExecerTimeHistogram_ms = "bzExecExecerTimeHistogram_ms"
 
 	/****************************** CAS Service ******************************************/
 	/*
-		FindMissingBlobs API metrics
+		FindMissingBlobs API metrics emitted by Apiserver
 	*/
-	BzFindBlobsSuccessCounter = "bzFindBlobsSuccessCounter"
-	BzFindBlobsFailureCounter = "bzFindBlobsFailureCounter"
-	BzFindBlobsLengthGauge    = "bzFindlobsLengthGauge"
-	BzFindBlobsLatency_ms     = "bzFindBlobsLatency_ms"
+	BzFindBlobsSuccessCounter  = "bzFindBlobsSuccessCounter"
+	BzFindBlobsFailureCounter  = "bzFindBlobsFailureCounter"
+	BzFindBlobsLengthHistogram = "bzFindlobsLengthHistogram"
+	BzFindBlobsLatency_ms      = "bzFindBlobsLatency_ms"
 
 	/*
-		CAS Read API metrics
+		CAS Read API metrics emitted by Apiserver
 	*/
 	BzReadSuccessCounter = "bzReadSuccessCounter"
 	BzReadFailureCounter = "bzReadFailureCounter"
-	BzReadBytesGauge     = "bzReadBytesGauge"
+	BzReadBytesHistogram = "bzReadBytesHistogram"
 	BzReadLatency_ms     = "bzReadLatency_ms"
 
 	/*
-		CAS Write API metrics
+		CAS Write API metrics emitted by Apiserver
 	*/
 	BzWriteSuccessCounter = "bzWriteSuccessCounter"
 	BzWriteFailureCounter = "bzWriteFailureCounter"
-	BzWriteBytesGauge     = "bzWriteBytesGauge"
+	BzWriteBytesHistogram = "bzWriteBytesHistogram"
 	BzWriteLatency_ms     = "bzWriteLatency_ms"
 
 	/****************************** ActionCache Service ****************************************/
 	/*
-		GetActionResult API metrics
+		GetActionResult API metrics emitted by Apiserver
 	*/
 	BzGetActionSuccessCounter = "bzGetActionSuccessCounter"
 	BzGetActionFailureCounter = "bzGetActionFailureCounter"
 	BzGetActionLatency_ms     = "bzGetActionLatency_ms"
 
 	/*
-		UpdateActionResult API metrics
+		UpdateActionResult API metrics emitted by Apiserver
 	*/
 	BzUpdateActionSuccessCounter = "bzUpdateActionSuccessCounter"
 	BzUpdateActionFailureCounter = "bzUpdateActionFailureCounter"

--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -543,7 +543,7 @@ const (
 	*/
 	BzFindBlobsSuccessCounter  = "bzFindBlobsSuccessCounter"
 	BzFindBlobsFailureCounter  = "bzFindBlobsFailureCounter"
-	BzFindBlobsLengthHistogram = "bzFindlobsLengthHistogram"
+	BzFindBlobsLengthHistogram = "bzFindBlobsLengthHistogram"
 	BzFindBlobsLatency_ms      = "bzFindBlobsLatency_ms"
 
 	/*

--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -516,89 +516,68 @@ const (
 
 	/****************************** Bazel Metrics **********************************************/
 
+	// TODO Gauge values not effective - just getting the last-set value at every metric post/publish interval
+	//	histogram the only effective way of doing this? P-vals like latency calculated & emitted each interval
+	//	probable have to add histogram to stats
+	// TODO Not clear from these what component they are emitted by
 	/****************************** Execution Service ******************************************/
 	/*
-		Number of Execute requests received
+		Execute API metrics
 	*/
-	BzExecRequestCounter = "bzExecRequestCounter"
+	BzExecSuccessCounter = "bzExecSuccessCounter"
+	BzExecFailureCounter = "bzExecFailureCounter"
+	BzExecLatency_ms     = "bzExecLatency_ms"
 
 	/*
-		Amount of time the server takes to process an Execute request
+		Longrunning GetOperation API metrics
 	*/
-	BzExecRequestLatency_ms = "bzExecRequestLatency_ms"
+	BzGetOpSuccessCounter = "bzGetOpSuccessCounter"
+	BzGetOpFailureCounter = "bzGetOpFailureCounter"
+	BzGetOpLatency_ms     = "bzGetOpLatency_ms"
 
 	/*
-		Number of GetOperation requests received
+		Execution metadata timing metrics
 	*/
-	BzGetOpRequestCounter = "bzGetOpRequestCounter"
-
-	/*
-		Amount of time the server takes to process a GetOperation request
-	*/
-	BzGetOpRequestLatency_ms = "bzGetOpRequestLatency_ms"
+	BzExecQueuedLatency_ms = "bzExecQueuedLatency_ms"
+	BzExecExecerTime_ms    = "bzExecExecerTime_ms"
 
 	/****************************** CAS Service ******************************************/
 	/*
-		Number of FindMissingBlobs requests received
+		FindMissingBlobs API metrics
 	*/
-	BzFindBlobsRequestCounter = "bzFindBlobsRequestCounter"
+	BzFindBlobsSuccessCounter = "bzFindBlobsSuccessCounter"
+	BzFindBlobsFailureCounter = "bzFindBlobsFailureCounter"
+	BzFindBlobsLengthGauge    = "bzFindlobsLengthGauge"
+	BzFindBlobsLatency_ms     = "bzFindBlobsLatency_ms"
 
 	/*
-		Amount of time the server takes to process a FindMissingBlobs request
+		CAS Read API metrics
 	*/
-	BzFindBlobsRequestLatency_ms = "bzFindBlobsRequestLatency_ms"
+	BzReadSuccessCounter = "bzReadSuccessCounter"
+	BzReadFailureCounter = "bzReadFailureCounter"
+	BzReadBytesGauge     = "bzReadBytesGauge"
+	BzReadLatency_ms     = "bzReadLatency_ms"
 
 	/*
-		Number of CAS Read requests received
+		CAS Write API metrics
 	*/
-	BzReadRequestCounter = "bzReadRequestCounter"
-
-	/*
-		Amount of time the server takes to process a CAS Read request
-	*/
-	BzReadRequestLatency_ms = "bzReadRequestLatency_ms"
-
-	/*
-		Number of CAS Write requests received
-	*/
-	BzWriteRequestCounter = "bzWriteRequestCounter"
-
-	/*
-		Amount of time the server takes to process a CAS Write request
-	*/
-	BzWriteRequestLatency_ms = "bzWriteRequestLatency_ms"
+	BzWriteSuccessCounter = "bzWriteSuccessCounter"
+	BzWriteFailureCounter = "bzWriteFailureCounter"
+	BzWriteBytesGauge     = "bzWriteBytesGauge"
+	BzWriteLatency_ms     = "bzWriteLatency_ms"
 
 	/****************************** ActionCache Service ****************************************/
 	/*
-		Number of GetActionResult requests received
+		GetActionResult API metrics
 	*/
-	BzGetActionRequestCounter = "bzGetActionRequestCounter"
+	BzGetActionSuccessCounter = "bzGetActionSuccessCounter"
+	BzGetActionFailureCounter = "bzGetActionFailureCounter"
+	BzGetActionLatency_ms     = "bzGetActionLatency_ms"
 
 	/*
-		Amount of time the server takes to process a GetActionResult request
+		UpdateActionResult API metrics
 	*/
-	BzGetActionRequestLatency_ms = "bzGetActionRequestLatency_ms"
-
-	/*
-		Number of UpdateActionResult requests received
-	*/
-	BzUpdateActionRequestCounter = "bzUpdateActionRequestCounter"
-
-	/*
-		Amount of time the server takes to process a UpdateActionResult request
-	*/
-	BzUpdateActionRequestLatency_ms = "bzUpdateActionRequestLatency_ms"
-
-	/* TODO
-	- execution tasks number of inputs/outputs. unknown except in snapshot impl!
-		- at checkout time - best we can do is total bytes and elapsed time from fs_util (dl bytes,ms per task)
-		- at upload time - best we can do is total bytes and elapsed time from fs_util (ul bytes,ms per task)
-	- execution metadata timings (record at worker invoker completion)
-		- queued time spent
-		- checkout time - downloadLatency (works for bazel?)
-		- exec time
-		- output upload time - uploadLatency (works for bazel?)
-	- cas read/write byte gauges
-	+ scheduler tick latency
-	*/
+	BzUpdateActionSuccessCounter = "bzUpdateActionSuccessCounter"
+	BzUpdateActionFailureCounter = "bzUpdateActionFailureCounter"
+	BzUpdateActionLatency_ms     = "bzUpdateActionLatency_ms"
 )

--- a/get_fs_util.sh
+++ b/get_fs_util.sh
@@ -2,18 +2,19 @@
 # Pulls in fs_util tool for use in remote exec ingestion, checkout, and CAS ops
 set -e
 
-pants_release="1.9.0.dev0%2B1e6ae97f"
+pants_release="1.9.0.dev0+1e6ae97f"
+pants_release_url=${pants_release/+/%2B}
 
 get_fs_util() {
 	case "$(uname -s)" in
 
 		Darwin)
-			local url="https://binaries.pantsbuild.org/bin/fs_util/mac/10.11/$pants_release/fs_util"
+			local url="https://binaries.pantsbuild.org/bin/fs_util/mac/10.11/$pants_release_url/fs_util"
 			echo "Fetching Darwin from $url"
 			;;
 
 		Linux)
-			local url="https://binaries.pantsbuild.org/bin/fs_util/linux/x86_64/$pants_release/fs_util"
+			local url="https://binaries.pantsbuild.org/bin/fs_util/linux/x86_64/$pants_release_url/fs_util"
 			echo "Fetching Linux from $url"
 			;;
 

--- a/get_fs_util.sh
+++ b/get_fs_util.sh
@@ -3,7 +3,7 @@
 set -e
 
 pants_release="1.9.0.dev0+1e6ae97f"
-pants_release_url="${pants_release/+/%2B}"
+pants_release_url=$(echo $pants_release | sed 's/+/%2B/')
 
 get_fs_util() {
 	case "$(uname -s)" in

--- a/get_fs_util.sh
+++ b/get_fs_util.sh
@@ -3,7 +3,7 @@
 set -e
 
 pants_release="1.9.0.dev0+1e6ae97f"
-pants_release_url=${pants_release/+/%2B}
+pants_release_url="${pants_release/+/%2B}"
 
 get_fs_util() {
 	case "$(uname -s)" in

--- a/runner/runners/bazel.go
+++ b/runner/runners/bazel.go
@@ -142,7 +142,7 @@ func postProcessBazel(filer snapshot.Filer,
 	coDir string,
 	stdout, stderr runner.Output,
 	st execer.ProcessStatus,
-	rts runTimes) (*bazelapi.ActionResult, error) {
+	rts *runTimes) (*bazelapi.ActionResult, error) {
 	bzFiler, ok := filer.(*bzsnapshot.BzFiler)
 	if !ok {
 		return nil, fmt.Errorf("Filer could not be asserted as type BzFiler. Type is: %s", reflect.TypeOf(filer))
@@ -177,6 +177,7 @@ func postProcessBazel(filer snapshot.Filer,
 
 	rts.outputEnd = stamp()
 	rts.invokeEnd = stamp()
+	rts.queuedTime = scootproto.GetTimeFromTimestamp(cmd.ExecuteRequest.GetExecutionMetadata().GetQueuedTimestamp())
 
 	// Update ExecutionMetadata with invoker runTimes data and existing queued time
 	// TODO Invoker should contain some metadata about the worker it lives on

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -415,8 +415,8 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 
 			queuedDuration := rts.invokeStart.Sub(rts.queuedTime)
 			execerTime := rts.execEnd.Sub(rts.execStart)
-			inv.stat.Gauge(stats.BzExecQueuedLatency_ms).Update(int64(queuedDuration / time.Millisecond))
-			inv.stat.Gauge(stats.BzExecExecerTime_ms).Update(int64(execerTime / time.Millisecond))
+			inv.stat.Histogram(stats.BzExecQueuedTimeHistogram_ms).Update(int64(queuedDuration / time.Millisecond))
+			inv.stat.Histogram(stats.BzExecExecerTimeHistogram_ms).Update(int64(execerTime / time.Millisecond))
 
 			status := runner.CompleteStatus(id, "", st.ExitCode,
 				tags.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID, Tag: cmd.Tag})

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -78,7 +78,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 
 	// Records various stages of the run
 	// TODO opporunity for consolidation with existing timers and metrics as part of larger refactor
-	var rts runTimes
+	rts := &runTimes{}
 	rts.invokeStart = stamp()
 
 	var co snapshot.Checkout
@@ -382,6 +382,12 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 			}
 			return status
 		} else if runType == runner.RunTypeBazel {
+			uploadTimer := inv.stat.Latency(stats.WorkerUploadLatency_ms).Time()
+			inv.stat.Counter(stats.WorkerUploads).Inc(1)
+			defer func() {
+				uploadTimer.Stop()
+			}()
+
 			// Process Bazel uploads of std* output and other data to CAS
 			ingestCh := make(chan interface{})
 			go func() {
@@ -406,6 +412,11 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 				}
 				actionResult = res.(*bazelapi.ActionResult)
 			}
+
+			queuedDuration := rts.invokeStart.Sub(rts.queuedTime)
+			execerTime := rts.execEnd.Sub(rts.execStart)
+			inv.stat.Gauge(stats.BzExecQueuedLatency_ms).Update(int64(queuedDuration / time.Millisecond))
+			inv.stat.Gauge(stats.BzExecExecerTime_ms).Update(int64(execerTime / time.Millisecond))
 
 			status := runner.CompleteStatus(id, "", st.ExitCode,
 				tags.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID, Tag: cmd.Tag})
@@ -470,6 +481,7 @@ type runTimes struct {
 	execEnd       time.Time
 	outputStart   time.Time
 	outputEnd     time.Time
+	queuedTime    time.Time // set by scheduler and must be populated e.g. by task metadata
 }
 
 // Wrapper around time values to encourage "stamp()" usage so it's harder to lose track of runTimes fields.


### PR DESCRIPTION
Bazel API endpoint metrics split into success/failure counts. Record histograms of per-request data (read bytes, write bytes, task times, etc).