### PR TITLE
Add stats for action cache check, action fetch, and command fetch

### DIFF
--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -538,9 +538,12 @@ const (
 		using that type results in these values being automatically cleared each
 		stat interval vs a gauge.
 	*/
-	BzExecQueuedTimeHistogram_ms     = "bzExecQueuedTimeHistogram_ms"
-	BzExecInputFetchTimeHistogram_ms = "bzExecInputFetchTimeHistogram_ms"
-	BzExecExecerTimeHistogram_ms     = "bzExecExecerTimeHistogram_ms"
+	BzExecQueuedTimeHistogram_ms           = "bzExecQueuedTimeHistogram_ms"
+	BzExecInputFetchTimeHistogram_ms       = "bzExecInputFetchTimeHistogram_ms"
+	BzExecActionCacheCheckTimeHistogram_ms = "BzExecActionCacheCheckTimeHistogram_ms"
+	BzExecActionFetchTimeHistogram_ms      = "BzExecActionFetchTimeHistogram_ms"
+	BzExecCommandFetchTimeHistogram_ms     = "BzExecCommandFetchTimeHistogram_ms"
+	BzExecExecerTimeHistogram_ms           = "bzExecExecerTimeHistogram_ms"
 
 	/****************************** CAS Service ******************************************/
 	/*

--- a/runner/runners/bazel.go
+++ b/runner/runners/bazel.go
@@ -58,14 +58,12 @@ func preProcessBazel(filer snapshot.Filer, cmd *runner.Command, rts *runTimes) (
 			}
 		} else if ar != nil {
 			log.Info("Returning cached result for command")
-			rts.actionFetchEnd = stamp()
 			return &bazelapi.ActionResult{
 				Result:       ar,
 				ActionDigest: cmd.ExecuteRequest.GetRequest().GetActionDigest(),
 				Cached:       true,
 			}, notExist, nil
 		}
-
 	}
 
 	missing, err := fetchBazelCommandData(bzFiler, cmd, rts)

--- a/runner/runners/bazel.go
+++ b/runner/runners/bazel.go
@@ -33,7 +33,7 @@ import (
 // Preliminary setup for handling Bazel commands - verify Filer and populate command.
 // Can return a bazelapi.ActionResult if a result was found already in the ActionCache.
 // Returns slice of any digests that could not be retrieved.
-func preProcessBazel(filer snapshot.Filer, cmd *runner.Command) (*bazelapi.ActionResult, []*remoteexecution.Digest, error) {
+func preProcessBazel(filer snapshot.Filer, cmd *runner.Command, rts *runTimes) (*bazelapi.ActionResult, []*remoteexecution.Digest, error) {
 	notExist := []*remoteexecution.Digest{}
 
 	bzFiler, ok := filer.(*bzsnapshot.BzFiler)
@@ -47,7 +47,9 @@ func preProcessBazel(filer snapshot.Filer, cmd *runner.Command) (*bazelapi.Actio
 	// Check for existing result in ActionCache
 	if !cmd.ExecuteRequest.GetRequest().GetSkipCacheLookup() {
 		log.Info("Checking for existing results for command in ActionCache")
+		rts.actionCacheCheckStart = stamp()
 		ar, err := cas.GetCacheResult(bzFiler.CASResolver, cmd.ExecuteRequest.GetRequest().GetActionDigest())
+		rts.actionCacheCheckEnd = stamp()
 		if err != nil {
 			// Only treat as an error if we didn't get NotFoundError. We still continue:
 			// cache lookup failure is internal, and should not prevent the run
@@ -56,15 +58,17 @@ func preProcessBazel(filer snapshot.Filer, cmd *runner.Command) (*bazelapi.Actio
 			}
 		} else if ar != nil {
 			log.Info("Returning cached result for command")
+			rts.actionFetchEnd = stamp()
 			return &bazelapi.ActionResult{
 				Result:       ar,
 				ActionDigest: cmd.ExecuteRequest.GetRequest().GetActionDigest(),
 				Cached:       true,
 			}, notExist, nil
 		}
+
 	}
 
-	missing, err := fetchBazelCommandData(bzFiler, cmd)
+	missing, err := fetchBazelCommandData(bzFiler, cmd, rts)
 	if err != nil {
 		log.Errorf("Error fetching Bazel command: %v", err)
 		// NB: Important to return this error as-is
@@ -79,10 +83,11 @@ func preProcessBazel(filer snapshot.Filer, cmd *runner.Command) (*bazelapi.Actio
 // Get the Bazel API data from the embedded ExecuteRequest ActionDigest.
 // Fetches Action, and from Action's CommandDigest, the Command.
 // Overwrites runner.Command fields
-func fetchBazelCommandData(bzFiler *bzsnapshot.BzFiler, cmd *runner.Command) ([]*remoteexecution.Digest, error) {
+func fetchBazelCommandData(bzFiler *bzsnapshot.BzFiler, cmd *runner.Command, rts *runTimes) ([]*remoteexecution.Digest, error) {
 	notExist := []*remoteexecution.Digest{}
 
 	log.Info("Fetching Bazel Action data from CAS server")
+	rts.actionFetchStart = stamp()
 	actionDigest := cmd.ExecuteRequest.GetRequest().GetActionDigest()
 	actionBytes, err := cas.ByteStreamRead(bzFiler.CASResolver, actionDigest)
 	if err != nil {
@@ -98,6 +103,7 @@ func fetchBazelCommandData(bzFiler *bzsnapshot.BzFiler, cmd *runner.Command) ([]
 	if err = proto.Unmarshal(actionBytes, action); err != nil {
 		return notExist, fmt.Errorf("Failed to unmarshal bytes as remoteexecution.Action: %s", err)
 	}
+	rts.actionFetchEnd = stamp()
 
 	d, err := time.ParseDuration(fmt.Sprintf("%dms", scootproto.GetMsFromDuration(action.GetTimeout())))
 	if err != nil {
@@ -105,6 +111,7 @@ func fetchBazelCommandData(bzFiler *bzsnapshot.BzFiler, cmd *runner.Command) ([]
 	}
 
 	log.Info("Fetching Bazel Command data from CAS server")
+	rts.commandFetchStart = stamp()
 	commandDigest := action.GetCommandDigest()
 	commandBytes, err := cas.ByteStreamRead(bzFiler.CASResolver, commandDigest)
 	if err != nil {
@@ -120,6 +127,7 @@ func fetchBazelCommandData(bzFiler *bzsnapshot.BzFiler, cmd *runner.Command) ([]
 	if err = proto.Unmarshal(commandBytes, bzCommand); err != nil {
 		return notExist, fmt.Errorf("Failed to unmarshal bytes as remoteexecution.Command: %s", err)
 	}
+	rts.commandFetchEnd = stamp()
 
 	// Update cmd's SnapshotID, Argv, EnvVars, and Timeout (overwrite) from Command
 	cmd.SnapshotID = bazel.SnapshotIDFromDigest(action.GetInputRootDigest())

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -120,6 +120,8 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 			return failedStatus
 		}
 		if cachedResult != nil {
+			actionCacheCheckTime := rts.actionCacheCheckEnd.Sub(rts.actionCacheCheckStart)
+			inv.stat.Histogram(stats.BzExecActionCacheCheckTimeHistogram_ms).Update(int64(actionCacheCheckTime / time.Millisecond))
 			status := runner.CompleteStatus(id, "", 0,
 				tags.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID, Tag: cmd.Tag})
 			status.ActionResult = cachedResult


### PR DESCRIPTION
Problem

Current stats implementation isn't granular enough to observe latency surrounding action cache & action/command fetches from CAS

Solution

Add stats for action cache check & action/command fetches

Result

Stats for action cache checks & action/command fetches will be available for consumption