### PR TITLE
Minor regexp improvements, additional Close()s

### DIFF
--- a/cloud/cluster/local/fetcher.go
+++ b/cloud/cluster/local/fetcher.go
@@ -4,6 +4,7 @@ package local
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -14,12 +15,17 @@ import (
 // Poor man's dynamic localhost cluster nodes.
 // Note: lsof is slow to return on osx so we just use 'ps' and regex match the port.
 func MakeFetcher(procName, portFlag string) cluster.Fetcher {
-	return &localFetcher{procName, portFlag}
+	return &localFetcher{
+		procName: procName,
+		addrFlag: portFlag,
+		re:       regexp.MustCompile(fmt.Sprintf("%s.*%s(?: +|=)([^ ]*)", procName, portFlag)),
+	}
 }
 
 type localFetcher struct {
 	procName string
 	addrFlag string
+	re       *regexp.Regexp
 }
 
 // Implements cluster.Fetcher interface for local Nodes via ps
@@ -27,7 +33,7 @@ func (f *localFetcher) Fetch() (nodes []cluster.Node, err error) {
 	var data []byte
 	if data, err = f.fetchData(); err != nil {
 		return nil, err
-	} else if nodes, err = parseData(data, f.procName, f.addrFlag); err != nil {
+	} else if nodes, err = parseData(data, f.procName, f.addrFlag, f.re); err != nil {
 		return nil, err
 	} else {
 		return nodes, nil
@@ -40,11 +46,11 @@ func (f *localFetcher) fetchData() ([]byte, error) {
 	return data, err
 }
 
-func parseData(data []byte, procName, addrFlag string) ([]cluster.Node, error) {
+func parseData(data []byte, procName, addrFlag string, re *regexp.Regexp) ([]cluster.Node, error) {
 	nodes := []cluster.Node{}
 	lines := string(data)
 	for _, line := range strings.Split(lines, "\n") {
-		thrift, err := parseFlag(line, procName, addrFlag)
+		thrift, err := parseFlag(line, procName, addrFlag, re)
 		if err == nil {
 			nodes = append(nodes, cluster.NewIdNode(thrift))
 		}
@@ -52,13 +58,10 @@ func parseData(data []byte, procName, addrFlag string) ([]cluster.Node, error) {
 	return nodes, nil
 }
 
-func parseFlag(line, procName, addrFlag string) (string, error) {
-	// This is ugly but it works for now.
-	re := regexp.MustCompile(procName + ".*" + addrFlag + "(?: +|=)([^ ]*)")
+func parseFlag(line, procName, addrFlag string, re *regexp.Regexp) (string, error) {
 	matches := re.FindStringSubmatch(line)
 	if len(matches) == 2 {
 		return matches[1], nil
 	}
 	return "", errors.New("Could not parse flag:'" + addrFlag + "', from line:'" + line + "'")
-
 }

--- a/cloud/cluster/local/fetcher_test.go
+++ b/cloud/cluster/local/fetcher_test.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/twitter/scoot/cloud/cluster"
@@ -19,8 +20,9 @@ func TestFetcher(t *testing.T) {
 		cluster.NewIdNode("localhost:9876"),
 		cluster.NewIdNode("localhost:9877"),
 	}
+	re := regexp.MustCompile("workerserver.*thrift_addr(?: +|=)([^ ]*)")
 
-	nodes, err := parseData([]byte(psOutput), "workerserver", "thrift_addr")
+	nodes, err := parseData([]byte(psOutput), "workerserver", "thrift_addr", re)
 	if err != nil {
 		t.Fatalf("error parsing: %v", err)
 	}

--- a/snapshot/bundlestore/http_server.go
+++ b/snapshot/bundlestore/http_server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -110,4 +111,14 @@ func (s *httpServer) HandleDownload(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	s.storeConfig.Stat.Counter(stats.BundlestoreDownloadOkCounter).Inc(1)
+}
+
+var bundleRE *regexp.Regexp = regexp.MustCompile("^bs-[a-z0-9]{40}.bundle")
+
+// Check for name enforcement for HTTP API
+func checkBundleName(name string) error {
+	if ok := bundleRE.MatchString(name); ok {
+		return nil
+	}
+	return fmt.Errorf("Error with bundleName, expected %q, got: %s", bundleRE, name)
 }

--- a/snapshot/bundlestore/server.go
+++ b/snapshot/bundlestore/server.go
@@ -1,9 +1,7 @@
 package bundlestore
 
 import (
-	"fmt"
 	"net/http"
-	"regexp"
 
 	log "github.com/sirupsen/logrus"
 
@@ -59,13 +57,3 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	s.storeConfig.Stat.Counter(stats.BundlestoreRequestOkCounter).Inc(1)
 }
-
-// Check for name enforcement for HTTP API
-func checkBundleName(name string) error {
-	if ok := bundleRE.MatchString(name); ok {
-		return nil
-	}
-	return fmt.Errorf("Error with bundleName, expected %q, got: %s", bundleRE, name)
-}
-
-bundleRE := regexp.MustCompile("^bs-[a-z0-9]{40}.bundle")

--- a/snapshot/bundlestore/server.go
+++ b/snapshot/bundlestore/server.go
@@ -62,9 +62,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 // Check for name enforcement for HTTP API
 func checkBundleName(name string) error {
-	bundleRE := "^bs-[a-z0-9]{40}.bundle"
-	if ok, _ := regexp.MatchString(bundleRE, name); ok {
+	if ok := bundleRE.MatchString(name); ok {
 		return nil
 	}
 	return fmt.Errorf("Error with bundleName, expected %q, got: %s", bundleRE, name)
 }
+
+bundleRE := regexp.MustCompile("^bs-[a-z0-9]{40}.bundle")

--- a/snapshot/git/gitdb/bundlestore.go
+++ b/snapshot/git/gitdb/bundlestore.go
@@ -262,6 +262,7 @@ func (s *bundlestoreSnapshot) downloadBundle(db *DB) (filename string, err error
 	if err != nil {
 		return "", err
 	}
+	defer r.Close()
 	if _, err := io.Copy(f, r); err != nil {
 		return "", err
 	}

--- a/snapshot/store/groupcache_store.go
+++ b/snapshot/store/groupcache_store.go
@@ -49,6 +49,7 @@ func MakeGroupcacheStore(underlying Store, cfg *GroupcacheConfig, stat stats.Sta
 			if err != nil {
 				return err
 			}
+			defer reader.Close()
 			data, err := ioutil.ReadAll(reader)
 			if err != nil {
 				return err

--- a/snapshot/store/groupcache_store.go
+++ b/snapshot/store/groupcache_store.go
@@ -44,7 +44,7 @@ func MakeGroupcacheStore(underlying Store, cfg *GroupcacheConfig, stat stats.Sta
 	var cache = groupcache.NewGroup(cfg.Name, cfg.Memory_bytes, groupcache.GetterFunc(
 		func(ctx groupcache.Context, bundleName string, dest groupcache.Sink) error {
 			log.Info("Not cached, try to fetch bundle and populate cache: ", bundleName)
-			stat.Counter(stats.BundlestoreGroupcacheReadUnderlyingCounter).Inc(1) // TODO errata metric - remove if unused
+			stat.Counter(stats.BundlestoreGroupcacheReadUnderlyingCounter).Inc(1)
 			reader, err := underlying.OpenForRead(bundleName)
 			if err != nil {
 				return err
@@ -100,23 +100,23 @@ func loop(c *cluster.Cluster, pool *groupcache.HTTPPool, cache *groupcache.Group
 // The groupcache lib updates its stats in the background - we need to convert those to our own stat representation.
 // Gauges are expected to fluctuate, counters are expected to only ever increase.
 func updateCacheStats(cache *groupcache.Group, stat stats.StatsReceiver) {
-	stat.Gauge(stats.GroupcacheMainBytesGauge).Update(cache.CacheStats(groupcache.MainCache).Bytes)   // TODO errata metric - remove if unused
-	stat.Gauge(stats.GroupcacheMainItemsGauge).Update(cache.CacheStats(groupcache.MainCache).Items)   // TODO errata metric - remove if unused
-	stat.Counter(stats.GroupcacheMainGetsCounter).Update(cache.CacheStats(groupcache.MainCache).Gets) // TODO errata metric - remove if unused
-	stat.Counter(stats.GroupcacheMainHitsCounter).Update(cache.CacheStats(groupcache.MainCache).Hits) // TODO errata metric - remove if unused
+	stat.Gauge(stats.GroupcacheMainBytesGauge).Update(cache.CacheStats(groupcache.MainCache).Bytes)
+	stat.Gauge(stats.GroupcacheMainItemsGauge).Update(cache.CacheStats(groupcache.MainCache).Items)
+	stat.Counter(stats.GroupcacheMainGetsCounter).Update(cache.CacheStats(groupcache.MainCache).Gets)
+	stat.Counter(stats.GroupcacheMainHitsCounter).Update(cache.CacheStats(groupcache.MainCache).Hits)
 
-	stat.Gauge(stats.GroupcacheHotBytesGauge).Update(cache.CacheStats(groupcache.HotCache).Bytes)   // TODO errata metric - remove if unused
-	stat.Gauge(stats.GroupcacheHotItemsGauge).Update(cache.CacheStats(groupcache.HotCache).Items)   // TODO errata metric - remove if unused
-	stat.Counter(stats.GroupcacheHotGetsCounter).Update(cache.CacheStats(groupcache.HotCache).Gets) // TODO errata metric - remove if unused
-	stat.Counter(stats.GroupcacheHotHitsCounter).Update(cache.CacheStats(groupcache.HotCache).Hits) // TODO errata metric - remove if unused
+	stat.Gauge(stats.GroupcacheHotBytesGauge).Update(cache.CacheStats(groupcache.HotCache).Bytes)
+	stat.Gauge(stats.GroupcacheHotItemsGauge).Update(cache.CacheStats(groupcache.HotCache).Items)
+	stat.Counter(stats.GroupcacheHotGetsCounter).Update(cache.CacheStats(groupcache.HotCache).Gets)
+	stat.Counter(stats.GroupcacheHotHitsCounter).Update(cache.CacheStats(groupcache.HotCache).Hits)
 
-	stat.Counter(stats.GroupcacheGetCounter).Update(cache.Stats.Gets.Get())                        // TODO errata metric - remove if unused
-	stat.Counter(stats.GroupcacheHitCounter).Update(cache.Stats.CacheHits.Get())                   // TODO errata metric - remove if unused
-	stat.Counter(stats.GroupcachePeerGetsCounter).Update(cache.Stats.PeerLoads.Get())              // TODO errata metric - remove if unused
-	stat.Counter(stats.GroupcachPeerErrCounter).Update(cache.Stats.PeerErrors.Get())               // TODO errata metric - remove if unused
-	stat.Counter(stats.GroupcacheLocalLoadCounter).Update(cache.Stats.LocalLoads.Get())            // TODO errata metric - remove if unused
-	stat.Counter(stats.GroupcacheLocalLoadErrCounter).Update(cache.Stats.LocalLoadErrs.Get())      // TODO errata metric - remove if unused
-	stat.Counter(stats.GroupcacheIncomingRequestsCounter).Update(cache.Stats.ServerRequests.Get()) // TODO errata metric - remove if unused
+	stat.Counter(stats.GroupcacheGetCounter).Update(cache.Stats.Gets.Get())
+	stat.Counter(stats.GroupcacheHitCounter).Update(cache.Stats.CacheHits.Get())
+	stat.Counter(stats.GroupcachePeerGetsCounter).Update(cache.Stats.PeerLoads.Get())
+	stat.Counter(stats.GroupcachPeerErrCounter).Update(cache.Stats.PeerErrors.Get())
+	stat.Counter(stats.GroupcacheLocalLoadCounter).Update(cache.Stats.LocalLoads.Get())
+	stat.Counter(stats.GroupcacheLocalLoadErrCounter).Update(cache.Stats.LocalLoadErrs.Get())
+	stat.Counter(stats.GroupcacheIncomingRequestsCounter).Update(cache.Stats.ServerRequests.Get())
 }
 
 type groupcacheStore struct {
@@ -133,7 +133,7 @@ func (s *groupcacheStore) OpenForRead(name string) (io.ReadCloser, error) {
 	if err := s.cache.Get(nil, name, groupcache.AllocatingByteSliceSink(&data)); err != nil {
 		return nil, err
 	}
-	s.stat.Counter(stats.GroupcacheReadOkCounter).Inc(1) // TODO errata metric - remove if unused
+	s.stat.Counter(stats.GroupcacheReadOkCounter).Inc(1)
 	return ioutil.NopCloser(bytes.NewReader(data)), nil
 }
 
@@ -144,7 +144,7 @@ func (s *groupcacheStore) Exists(name string) (bool, error) {
 	if err := s.cache.Get(nil, name, groupcache.TruncatingByteSliceSink(&[]byte{})); err != nil {
 		return false, nil
 	}
-	s.stat.Counter(stats.GroupcacheExistsOkCounter).Inc(1) // TODO errata metric - remove if unused
+	s.stat.Counter(stats.GroupcacheExistsOkCounter).Inc(1)
 	return true, nil
 }
 
@@ -162,7 +162,7 @@ func (s *groupcacheStore) Write(name string, data io.Reader, ttl *TTLValue) erro
 	}
 
 	s.cache.PopulateCache(name, b)
-	s.stat.Counter(stats.GroupcacheWriteOkCounter).Inc(1) // TODO errata metric - remove if unused
+	s.stat.Counter(stats.GroupcacheWriteOkCounter).Inc(1)
 	return nil
 }
 


### PR DESCRIPTION
* The Close() calls are unlikely to be culprits of runaway memory usage, but we should have them in any case for completeness.
* The regexp calls were inefficient - compiling each time. The local fetcher change does not impact closed source production environment, but the http server name check (which should eventually be deleted) was causing very significant allocations to compile each time (although again, not a leak).