### PR TITLE
apiserver/groupcache - populate cache with correctly-sized/capped byte slice

### DIFF
--- a/snapshot/store/groupcache_store.go
+++ b/snapshot/store/groupcache_store.go
@@ -165,7 +165,7 @@ func (s *groupcacheStore) Write(name string, data io.Reader, ttl *TTLValue) erro
 	c := make([]byte, len(b))
 	copy(c, b)
 
-	err = s.underlying.Write(name, data, ttl)
+	err = s.underlying.Write(name, bytes.NewBuffer(b), ttl)
 	if err != nil {
 		return err
 	}

--- a/snapshot/store/groupcache_store.go
+++ b/snapshot/store/groupcache_store.go
@@ -156,16 +156,21 @@ func (s *groupcacheStore) Write(name string, data io.Reader, ttl *TTLValue) erro
 	log.Info("Write() populating cache: ", name)
 	defer s.stat.Latency(stats.GroupcacheWriteLatency_ms).Time().Stop()
 	s.stat.Counter(stats.GroupcacheWriteCounter).Inc(1)
+
+	// Read data into a []byte and make a right-sized copy, as ReadAll will reserve at 2x capacity
 	b, err := ioutil.ReadAll(data)
 	if err != nil {
 		return err
 	}
-	err = s.underlying.Write(name, bytes.NewBuffer(b), ttl)
+	c := make([]byte, len(b))
+	copy(c, b)
+
+	err = s.underlying.Write(name, data, ttl)
 	if err != nil {
 		return err
 	}
 
-	s.cache.PopulateCache(name, b)
+	s.cache.PopulateCache(name, c)
 	s.stat.Counter(stats.GroupcacheWriteOkCounter).Inc(1)
 	return nil
 }


### PR DESCRIPTION
Prior fixes reduced the heap growth rate, but we still had an underlying issue that we would retain 2x the configured groupcache size. This was entirely due to ioutil.ReadAll resulting in a []byte with twice the capacity of the length of the data (standard behavior).

Because we can't see the length of the data from the Reader, we have to make an additional copy after the readall and pass that to cache population.