### PR TITLE
cas,bundlestore - limit maximum connection access to underlying store resources

### DIFF
--- a/bazel/cas/constants.go
+++ b/bazel/cas/constants.go
@@ -15,6 +15,9 @@ const (
 
 	// ActionCache constants
 	ResultAddressKey = "ActionCacheResult"
+
+	// Maximum concurrent connections allowed to access underlying Store resources
+	MaxConnections = 100
 )
 
 // Resource naming format guidelines

--- a/bazel/cas/service.go
+++ b/bazel/cas/service.go
@@ -439,10 +439,6 @@ func (s *casServer) GetActionResult(ctx context.Context,
 	if !s.IsInitialized() {
 		return nil, status.Error(codes.Internal, "Server not initialized")
 	}
-	if s.concurrent != nil {
-		s.concurrent <- struct{}{}
-		defer func() { <-s.concurrent }()
-	}
 
 	var err error = nil
 
@@ -514,10 +510,6 @@ func (s *casServer) UpdateActionResult(ctx context.Context,
 
 	if !s.IsInitialized() {
 		return nil, status.Error(codes.Internal, "Server not initialized")
-	}
-	if s.concurrent != nil {
-		s.concurrent <- struct{}{}
-		defer func() { <-s.concurrent }()
 	}
 
 	var err error = nil

--- a/snapshot/bundlestore/constants.go
+++ b/snapshot/bundlestore/constants.go
@@ -3,4 +3,7 @@ package bundlestore
 const (
 	// Store-related environment variables
 	BundlestoreDirEnvVar = "BUNDLESTORE_STORE_DIR"
+
+	// Maximum concurrent connections allowed to access underlying Store resources
+	MaxConnections = 100
 )

--- a/snapshot/bundlestore/server.go
+++ b/snapshot/bundlestore/server.go
@@ -22,6 +22,7 @@ type Server struct {
 	storeConfig *store.StoreConfig
 	httpServer  *httpServer
 	casServer   bazel.GRPCServer
+	concurrent  chan struct{}
 }
 
 // Make a new server that delegates to an underlying store.
@@ -37,11 +38,17 @@ func MakeServer(s store.Store, ttl *store.TTLConfig, stat stats.StatsReceiver, l
 		storeConfig: cfg,
 		httpServer:  MakeHTTPServer(cfg),
 		casServer:   cas.MakeCASServer(l, cfg, stat),
+		concurrent:  make(chan struct{}, MaxConnections),
 	}
 }
 
 // Implements http.Handler interface
 func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if s.concurrent != nil {
+		s.concurrent <- struct{}{}
+		defer func() { <-s.concurrent }()
+	}
+
 	s.storeConfig.Stat.Counter(stats.BundlestoreRequestCounter).Inc(1)
 	switch req.Method {
 	case "POST":


### PR DESCRIPTION
Most basic limiter implementation. Don't limit incoming connections because they are cheap, but block on access to underlying store from incoming areas: bundlestore server HTTP API and CAS grpc API. The APIs can use  a separate max as it's unlikely a thundering herd will hit the APIs at the same time as the use cases are somewhat different.

Max of 100 is arbitrary but reasonable based on typical observed use cases: a 10MB object (which is well on the larger side) would result in a maximum 1GB memory usage spike.

In the future we will like to make this command line configurable.