### PR TITLE
bazel,snapshot - shortcuts for empty digest operations on client read, write, and checkout

### DIFF
--- a/bazel/cas/client.go
+++ b/bazel/cas/client.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/twitter/scoot/bazel"
 	"github.com/twitter/scoot/common/dialer"
 )
 
@@ -45,6 +46,11 @@ func IsNotFoundError(err error) bool {
 // Returns bytes read or an error. If the requested resource was not found,
 // returns a NotFoundError
 func ByteStreamRead(r dialer.Resolver, digest *remoteexecution.Digest) ([]byte, error) {
+	// skip request processing for empty sha
+	if digest == nil || bazel.IsEmptyDigest(digest) {
+		return nil, nil
+	}
+
 	serverAddr, err := r.Resolve()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to resolve server address: %s", err)
@@ -108,6 +114,11 @@ func readFromClient(bsc bytestream.ByteStreamClient, req *bytestream.ReadRequest
 
 // Write data as bytes to a CAS. Takes a Resolver for addressing, a bazel Digest to read, and []byte data.
 func ByteStreamWrite(r dialer.Resolver, digest *remoteexecution.Digest, data []byte) error {
+	// skip request processing for empty sha
+	if digest == nil || bazel.IsEmptyDigest(digest) {
+		return nil
+	}
+
 	serverAddr, err := r.Resolve()
 	if err != nil {
 		return fmt.Errorf("Failed to resolve server address: %s", err)

--- a/bazel/cas/client_test.go
+++ b/bazel/cas/client_test.go
@@ -21,8 +21,10 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/twitter/scoot/bazel"
 	"github.com/twitter/scoot/bazel/cas/mock_bytestream"
 	"github.com/twitter/scoot/bazel/execution/mock_remoteexecution"
+	"github.com/twitter/scoot/common/dialer"
 )
 
 func TestClientRead(t *testing.T) {
@@ -69,6 +71,17 @@ func TestClientReadMissing(t *testing.T) {
 	}
 }
 
+func TestClientReadEmpty(t *testing.T) {
+	digest := &remoteexecution.Digest{
+		Hash:      bazel.EmptySha,
+		SizeBytes: bazel.EmptySize,
+	}
+	data, err := ByteStreamRead(dialer.NewConstantResolver(""), digest)
+	if data != nil || err != nil {
+		t.Fatal("Expected nil data and err from empty client read")
+	}
+}
+
 func TestClientWrite(t *testing.T) {
 	// Make a WriteRequest with known data
 	offset, limit := int64(0), testSize1
@@ -86,6 +99,17 @@ func TestClientWrite(t *testing.T) {
 	err := writeFromClient(bsClientMock, req)
 	if err != nil {
 		t.Fatalf("Error from client write: %s", err)
+	}
+}
+
+func TestClientWriteEmpty(t *testing.T) {
+	digest := &remoteexecution.Digest{
+		Hash:      bazel.EmptySha,
+		SizeBytes: bazel.EmptySize,
+	}
+	err := ByteStreamWrite(dialer.NewConstantResolver(""), digest, nil)
+	if err != nil {
+		t.Fatal("Expected nil err from empty client write")
 	}
 }
 

--- a/bazel/digest.go
+++ b/bazel/digest.go
@@ -45,3 +45,7 @@ func DigestToStr(d *remoteexecution.Digest) string {
 	}
 	return fmt.Sprintf("%s/%d", d.GetHash(), d.GetSizeBytes())
 }
+
+func IsEmptyDigest(d *remoteexecution.Digest) bool {
+	return d.GetHash() == EmptySha && d.GetSizeBytes() == EmptySize
+}

--- a/bazel/digest_test.go
+++ b/bazel/digest_test.go
@@ -47,3 +47,20 @@ func TestDigestFromString(t *testing.T) {
 		t.Fatalf("Failed to create digest from string: %s", err)
 	}
 }
+
+func TestEmptyDigest(t *testing.T) {
+	d1 := &remoteexecution.Digest{
+		Hash:      EmptySha,
+		SizeBytes: EmptySize,
+	}
+	d2 := &remoteexecution.Digest{
+		Hash:      "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+		SizeBytes: 123,
+	}
+	if !IsEmptyDigest(d1) {
+		t.Fatal("Empty hash/size not recognized")
+	}
+	if IsEmptyDigest(d2) {
+		t.Fatal("Non-empty hash/size false positive")
+	}
+}

--- a/snapshot/bazel/bz_tree.go
+++ b/snapshot/bazel/bz_tree.go
@@ -2,6 +2,7 @@ package bazel
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 
@@ -78,6 +79,11 @@ func (bc bzCommand) save(path string) (string, error) {
 
 // Materializes the digest identified by sha in dir using the fsUtilCmd
 func (bc bzCommand) materialize(sha string, size int64, dir string) error {
+	// short circuit if the input is empty, but create the target dir as fs_util would do
+	if sha == bazel.EmptySha && size == bazel.EmptySize {
+		return os.Mkdir(dir, 0777)
+	}
+
 	// we don't expect there to be any useful output
 	_, err := bc.runCmd([]string{fsUtilCmdDirectory, fsUtilCmdMaterialize, sha, strconv.FormatInt(size, 10), dir})
 	if err != nil {

--- a/snapshot/bazel/fs_util_test.go
+++ b/snapshot/bazel/fs_util_test.go
@@ -189,3 +189,30 @@ func TestMaterializeDir(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestMaterializeEmptyDir(t *testing.T) {
+	root, err := tmpTest.TempDir("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDirPrefix := "tmp"
+	tmpDir, err := root.TempDir(tmpDirPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id := bazel.SnapshotID(bazel.EmptySha, bazel.EmptySize)
+	bf := makeTestingFiler()
+
+	co, err := bf.Checkout(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	output, err := exec.Command("diff", "-r", co.Path(), tmpDir.Dir).Output()
+	if string(output) != "" {
+		t.Fatalf("Expected %s and %s to be equivalent, instead received \"%s\" from command", co.Path(), tmpDir.Dir, string(output))
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Bypass network calls in the CAS client libraries for Reading and Writing empty data. Skip calling fs_util when materializing/Checkout'ing an empty input root.