### PR TITLE
bazel/cas - connection, rate, stream limiting

### DIFF
--- a/bazel/cas/constants.go
+++ b/bazel/cas/constants.go
@@ -16,8 +16,11 @@ const (
 	// ActionCache constants
 	ResultAddressKey = "ActionCacheResult"
 
-	// Maximum concurrent connections allowed to access underlying Store resources
-	MaxConnections = 100
+	// GRPC Server connection-related setting limits
+	MaxSimultaneousConnections = 200 // limits total simultaneous connections via the Listener
+	MaxRequestsPerSecond       = 100 // limits total incoming requests allowed per second
+	MaxRequestsBurst           = 20  // allows this many requests in a burst faster than MaxRPS average
+	MaxConcurrentStreams       = 10  // limits concurrent streams _per client_
 )
 
 // Resource naming format guidelines

--- a/bazel/cas/constants.go
+++ b/bazel/cas/constants.go
@@ -16,7 +16,7 @@ const (
 	// ActionCache constants
 	ResultAddressKey = "ActionCacheResult"
 
-	// GRPC Server connection-related setting limits
+	// GRPC Server connection-related setting limits recommended for CAS
 	MaxSimultaneousConnections = 200 // limits total simultaneous connections via the Listener
 	MaxRequestsPerSecond       = 100 // limits total incoming requests allowed per second
 	MaxRequestsBurst           = 20  // allows this many requests in a burst faster than MaxRPS average

--- a/bazel/cas/service.go
+++ b/bazel/cas/service.go
@@ -64,7 +64,7 @@ type tapLimiter struct {
 
 // TODO experimental
 func newTap() *tapLimiter {
-	return &tapLimiter{limiter: rate.NewLimiter(200, 20)}
+	return &tapLimiter{limiter: rate.NewLimiter(100, 20)}
 }
 
 func (t *tapLimiter) Handler(ctx context.Context, info *tap.Info) (context.Context, error) {

--- a/bazel/cas/service.go
+++ b/bazel/cas/service.go
@@ -43,11 +43,12 @@ type casServer struct {
 // TODO closed src apiserver main.go is set up with a LimitListener at 100
 func MakeCASServer(l net.Listener, cfg *store.StoreConfig, stat stats.StatsReceiver) *casServer {
 	// TODO experimental
-	maxStreamOpt := grpc.MaxConcurrentStreams(100)
-	tapLimiterOpt := grpc.InTapHandle(newTap().Handler)
+	maxStreamOpt := grpc.MaxConcurrentStreams(10)
+	//tapLimiterOpt := grpc.InTapHandle(newTap().Handler)
 	g := casServer{
-		listener:    l,
-		server:      grpchelpers.NewServer(maxStreamOpt, tapLimiterOpt),
+		listener: l,
+		server:   grpchelpers.NewServer(maxStreamOpt),
+		//server:      grpchelpers.NewServer(maxStreamOpt, tapLimiterOpt),
 		storeConfig: cfg,
 		stat:        stat,
 		//concurrent:  make(chan struct{}, MaxConnections), TODO left as nil to disable blocking
@@ -164,6 +165,7 @@ func (s *casServer) GetTree(
 
 // Serves content in the bundlestore to a client via grpc streaming.
 // Implements googleapis bytestream Read
+// TODO one log per request...
 func (s *casServer) Read(req *bytestream.ReadRequest, ser bytestream.ByteStream_ReadServer) error {
 	log.Debugf("Received CAS Read request: %s", req)
 

--- a/bazel/cas/service.go
+++ b/bazel/cas/service.go
@@ -68,12 +68,7 @@ func newTap() *tapLimiter {
 }
 
 func (t *tapLimiter) Handler(ctx context.Context, info *tap.Info) (context.Context, error) {
-	// if no deadline is set in context, add one so this request can time out
-	if _, ok := ctx.Deadline(); !ok {
-		ctx, _ = context.WithDeadline(ctx, time.Now().Add(10*time.Second))
-	}
-	err := t.limiter.Wait(ctx)
-	if err != nil {
+	if !t.limiter.Allow() {
 		log.Error("Tap dropped connection waiting for rate limiter")
 		return nil, status.Errorf(codes.ResourceExhausted, "Service exhausted while waiting for rate limiter")
 	}

--- a/bazel/cas/service.go
+++ b/bazel/cas/service.go
@@ -44,11 +44,10 @@ type casServer struct {
 func MakeCASServer(l net.Listener, cfg *store.StoreConfig, stat stats.StatsReceiver) *casServer {
 	// TODO experimental
 	maxStreamOpt := grpc.MaxConcurrentStreams(10)
-	//tapLimiterOpt := grpc.InTapHandle(newTap().Handler)
+	tapLimiterOpt := grpc.InTapHandle(newTap().Handler)
 	g := casServer{
-		listener: l,
-		server:   grpchelpers.NewServer(maxStreamOpt),
-		//server:      grpchelpers.NewServer(maxStreamOpt, tapLimiterOpt),
+		listener:    l,
+		server:      grpchelpers.NewServer(maxStreamOpt, tapLimiterOpt),
 		storeConfig: cfg,
 		stat:        stat,
 		//concurrent:  make(chan struct{}, MaxConnections), TODO left as nil to disable blocking
@@ -65,7 +64,7 @@ type tapLimiter struct {
 
 // TODO experimental
 func newTap() *tapLimiter {
-	return &tapLimiter{limiter: rate.NewLimiter(1000, 100)}
+	return &tapLimiter{limiter: rate.NewLimiter(200, 20)}
 }
 
 func (t *tapLimiter) Handler(ctx context.Context, info *tap.Info) (context.Context, error) {

--- a/bazel/cas/service.go
+++ b/bazel/cas/service.go
@@ -39,9 +39,10 @@ type casServer struct {
 // Creates a new GRPCServer (CASServer/ByteStreamServer/ActionCacheServer)
 // based on a listener, and preregisters the service
 func MakeCASServer(l net.Listener, cfg *store.StoreConfig, stat stats.StatsReceiver) *casServer {
+	opt := grpc.MaxConcurrentStreams(100)
 	g := casServer{
 		listener:    l,
-		server:      grpchelpers.NewServer(),
+		server:      grpchelpers.NewServer(opt),
 		storeConfig: cfg,
 		stat:        stat,
 		concurrent:  make(chan struct{}, MaxConnections),

--- a/bazel/server.go
+++ b/bazel/server.go
@@ -3,6 +3,17 @@ package bazel
 
 import (
 	"net"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+	"golang.org/x/net/netutil"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/tap"
+
+	"github.com/twitter/scoot/common/grpchelpers"
 )
 
 // Wrapping interface for gRPC servers to work seamlessly with magicbag semantics
@@ -13,5 +24,69 @@ type GRPCServer interface {
 	Serve() error
 }
 
-// Type alias for clarity in use for certain listeners
-type GRPCListener net.Listener
+// GRPCConfig holds fields used for configuring startup of GRPC Listeners and Servers
+// Zero value integer fields are interpretted as unlimited
+type GRPCConfig struct {
+	GRPCAddr          string // Required: ip:port the Listener will bind to
+	ListenerMaxConns  int    // Maximum simultaneous connections the listener will accept
+	RateLimitPerSec   int    // Maximum incoming requests per second
+	BurstLimitPerSec  int    // Maximum per-burst incoming requests per second (within RateLimitPerSec)
+	ConcurrentStreams int    // Maximum concurrent GRPC streams allowed per client
+}
+
+// Creates a new net.Listener with the configured address and limits
+func (c *GRPCConfig) NewListener() (net.Listener, error) {
+	listener, err := net.Listen("tcp", c.GRPCAddr)
+	if err != nil {
+		return nil, err
+	}
+	if c.ListenerMaxConns > 0 {
+		log.Infof("Creating LimitListener with max: %d", c.ListenerMaxConns)
+		limitListener := netutil.LimitListener(listener, c.ListenerMaxConns)
+		return limitListener, nil
+	}
+	return listener, nil
+}
+
+// Creates a new *grpc.Server configured with ServerOptions based on the GRPCConfig fields
+func (c *GRPCConfig) NewGRPCServer() *grpc.Server {
+	var serverOpts []grpc.ServerOption
+
+	// 0 is a valid Limiter that rejects all requests, but that's not useful, so we interpret 0 as unlimited
+	if c.RateLimitPerSec > 0 && c.BurstLimitPerSec > 0 {
+		log.Infof("Creating Limiter with rate/burst: %d/%d", c.RateLimitPerSec, c.BurstLimitPerSec)
+		limiterOpt := grpc.InTapHandle(NewTap(c.RateLimitPerSec, c.BurstLimitPerSec).Handler)
+		serverOpts = append(serverOpts, limiterOpt)
+	}
+
+	if c.ConcurrentStreams > 0 {
+		log.Infof("Setting concurrent streams limit: %d", c.ConcurrentStreams)
+		streamsOpt := grpc.MaxConcurrentStreams(uint32(c.ConcurrentStreams))
+		serverOpts = append(serverOpts, streamsOpt)
+	}
+
+	return grpchelpers.NewServer(serverOpts...)
+}
+
+// Encapsulates a rate-per-second limiter that will check all incoming requests (per-connection goroutine)
+// Handle func Fulfills grpc/tap.ServerInHandle
+type TapLimiter struct {
+	limiter *rate.Limiter
+}
+
+// Create a new TapLimiter with specified rate and burst allowance
+func NewTap(maxRequests, maxBurst int) *TapLimiter {
+	return &TapLimiter{
+		limiter: rate.NewLimiter(rate.Limit(maxRequests), maxBurst),
+	}
+}
+
+// Wait until the Limiter allows the a request or the Context expires
+// Client sees non-nil err as an RPC error with code=Unavailable, desc includes RST_STREAM or REFUSED_STREAM
+func (t *TapLimiter) Handler(ctx context.Context, info *tap.Info) (context.Context, error) {
+	if err := t.limiter.Wait(ctx); err != nil {
+		log.Warnf("Tap limiter dropped connection due to rate limit: %s. Incoming request: %s", err, info.FullMethodName)
+		return nil, status.Error(codes.ResourceExhausted, "Resource exhausted due to rate limit")
+	}
+	return ctx, nil
+}

--- a/common/grpchelpers/server.go
+++ b/common/grpchelpers/server.go
@@ -5,6 +5,8 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
+// This package can be relocated/deprecated when the daemon is removed
+
 // NewServer returns a new grpc server just like grpc.NewServer(), but
 // which automatically implements the grpc server reflection protocol.
 // See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md

--- a/scootapi/server/setup.go
+++ b/scootapi/server/setup.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"net"
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
@@ -89,12 +88,14 @@ func Defaults() (*ice.MagicBag, jsonconfig.Schema) {
 			return thrift.NewTBinaryProtocolFactoryDefault()
 		},
 
-		func() (bazel.GRPCListener, error) {
-			return net.Listen("tcp", scootapi.DefaultSched_GRPC)
+		func() *bazel.GRPCConfig {
+			return &bazel.GRPCConfig{
+				GRPCAddr: scootapi.DefaultSched_GRPC,
+			}
 		},
 
-		func(l bazel.GRPCListener, s scheduler.Scheduler, stat stats.StatsReceiver) bazel.GRPCServer {
-			return execution.MakeExecutionServer(l, s, stat)
+		func(gc *bazel.GRPCConfig, s scheduler.Scheduler, stat stats.StatsReceiver) bazel.GRPCServer {
+			return execution.MakeExecutionServer(gc, s, stat)
 		},
 	)
 

--- a/snapshot/bundlestore/server.go
+++ b/snapshot/bundlestore/server.go
@@ -27,7 +27,7 @@ type Server struct {
 // Make a new server that delegates to an underlying store.
 // TTL may be nil, in which case defaults are applied downstream.
 // TTL duration may be overriden by request headers, but we always pass this TTLKey to the store.
-func MakeServer(s store.Store, ttl *store.TTLConfig, stat stats.StatsReceiver, l bazel.GRPCListener) *Server {
+func MakeServer(s store.Store, ttl *store.TTLConfig, stat stats.StatsReceiver, gc *bazel.GRPCConfig) *Server {
 	scopedStat := stat.Scope("bundlestoreServer")
 	go stats.StartUptimeReporting(scopedStat, stats.BundlestoreUptime_ms, stats.BundlestoreServerStartedGauge, stats.DefaultStartupGaugeSpikeLen)
 	cfg := &store.StoreConfig{Store: s, TTLCfg: ttl, Stat: scopedStat}
@@ -36,7 +36,7 @@ func MakeServer(s store.Store, ttl *store.TTLConfig, stat stats.StatsReceiver, l
 	return &Server{
 		storeConfig: cfg,
 		httpServer:  MakeHTTPServer(cfg),
-		casServer:   cas.MakeCASServer(l, cfg, stat),
+		casServer:   cas.MakeCASServer(gc, cfg, stat),
 	}
 }
 

--- a/snapshot/bundlestore/setup.go
+++ b/snapshot/bundlestore/setup.go
@@ -1,7 +1,6 @@
 package bundlestore
 
 import (
-	"net"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -59,8 +58,10 @@ func Defaults() *ice.MagicBag {
 			return makeServers(h, g)
 		},
 
-		func() (bazel.GRPCListener, error) {
-			return net.Listen("tcp", scootapi.DefaultApiBundlestore_GRPC)
+		func() *bazel.GRPCConfig {
+			return &bazel.GRPCConfig{
+				GRPCAddr: scootapi.DefaultApiBundlestore_GRPC,
+			}
 		},
 
 		func(s *Server) bazel.GRPCServer {


### PR DESCRIPTION
Prevent memory usage spikes in CAS apiserver that occur during high concurrent request traffic. The spikes are caused by additional allocations done in grpc internals that can accumulate rapidly during extreme request load. Limiting CAS API implementations doesn't stop these accumulations as they are held until the underlying rpc/stream/connection/? is closed.

This introduces 3 types of limits:
* A netutil.LimitListener that limits overall simultaneous connections at the listener level
* A rate.Limiter implemented in the grpc server InTap handler that makes incoming requests wait if over threshold
* A MaxConcurrentStreams grpc server option that caps the number of concurrent streams per client connected to the apiserver

This replaces the previous buffered-channel-based limiter in the CAS API implementations that did not prevent this problem.

These are configured via const values but could be extended to be configurable by command line arguments.