### PR TITLE
bazel/cas - client APIs get simple retries, remove pedantic checks in unexported functions

### DIFF
--- a/bazel/cas/client.go
+++ b/bazel/cas/client.go
@@ -51,6 +51,9 @@ func ByteStreamRead(r dialer.Resolver, digest *remoteexecution.Digest, retries i
 	if digest == nil || bazel.IsEmptyDigest(digest) {
 		return nil, nil
 	}
+	if retries < 0 {
+		retries = 0
+	}
 
 	for ; retries >= 0; retries-- {
 		bytes, err = byteStreamRead(r, digest)
@@ -124,6 +127,9 @@ func ByteStreamWrite(r dialer.Resolver, digest *remoteexecution.Digest, data []b
 	if digest == nil || bazel.IsEmptyDigest(digest) {
 		return nil
 	}
+	if retries < 0 {
+		retries = 0
+	}
 
 	for ; retries >= 0; retries-- {
 		err = byteStreamWrite(r, digest, data)
@@ -189,6 +195,9 @@ func writeFromClient(bsc bytestream.ByteStreamClient, req *bytestream.WriteReque
 // Client function for GetActionResult requests. Takes a Resolver for ActionCache server and Digest to get.
 // If retries > 0, does simple retry attempts when encountering errors
 func GetCacheResult(r dialer.Resolver, digest *remoteexecution.Digest, retries int) (ar *remoteexecution.ActionResult, err error) {
+	if retries < 0 {
+		retries = 0
+	}
 	for ; retries >= 0; retries-- {
 		ar, err = getCacheResult(r, digest)
 
@@ -237,6 +246,9 @@ func getCacheFromClient(acc remoteexecution.ActionCacheClient,
 // If retries > 0, does simple retry attempts when encountering errors
 func UpdateCacheResult(r dialer.Resolver, digest *remoteexecution.Digest,
 	ar *remoteexecution.ActionResult, retries int) (out *remoteexecution.ActionResult, err error) {
+	if retries < 0 {
+		retries = 0
+	}
 	for ; retries >= 0; retries-- {
 		out, err = updateCacheResult(r, digest, ar)
 

--- a/bazel/cas/client_test.go
+++ b/bazel/cas/client_test.go
@@ -76,7 +76,7 @@ func TestClientReadEmpty(t *testing.T) {
 		Hash:      bazel.EmptySha,
 		SizeBytes: bazel.EmptySize,
 	}
-	data, err := ByteStreamRead(dialer.NewConstantResolver(""), digest)
+	data, err := ByteStreamRead(dialer.NewConstantResolver(""), digest, 0)
 	if data != nil || err != nil {
 		t.Fatal("Expected nil data and err from empty client read")
 	}
@@ -107,7 +107,7 @@ func TestClientWriteEmpty(t *testing.T) {
 		Hash:      bazel.EmptySha,
 		SizeBytes: bazel.EmptySize,
 	}
-	err := ByteStreamWrite(dialer.NewConstantResolver(""), digest, nil)
+	err := ByteStreamWrite(dialer.NewConstantResolver(""), digest, nil, 0)
 	if err != nil {
 		t.Fatal("Expected nil err from empty client write")
 	}

--- a/binaries/bzutil/main.go
+++ b/binaries/bzutil/main.go
@@ -178,7 +178,7 @@ func uploadBzCommand(cmdArgs []string, casAddr, env, outputFilesStr, outputDirsS
 	// upload command to CAS
 	r := dialer.NewConstantResolver(casAddr)
 	digest := &remoteexecution.Digest{Hash: hash, SizeBytes: size}
-	err = cas.ByteStreamWrite(r, digest, bytes)
+	err = cas.ByteStreamWrite(r, digest, bytes, 1)
 	if err != nil {
 		log.Fatalf("Error writing to CAS: %s", err)
 	}
@@ -223,7 +223,7 @@ func uploadBzAction(casAddr, commandDigestStr, rootDigestStr string, noCache, ac
 	// upload action to CAS
 	r := dialer.NewConstantResolver(casAddr)
 	digest := &remoteexecution.Digest{Hash: hash, SizeBytes: size}
-	err = cas.ByteStreamWrite(r, digest, bytes)
+	err = cas.ByteStreamWrite(r, digest, bytes, 1)
 	if err != nil {
 		log.Fatalf("Error writing to CAS: %s", err)
 	}

--- a/runner/runners/bazel.go
+++ b/runner/runners/bazel.go
@@ -48,7 +48,7 @@ func preProcessBazel(filer snapshot.Filer, cmd *runner.Command, rts *runTimes) (
 	if !cmd.ExecuteRequest.GetRequest().GetSkipCacheLookup() {
 		log.Info("Checking for existing results for command in ActionCache")
 		rts.actionCacheCheckStart = stamp()
-		ar, err := cas.GetCacheResult(bzFiler.CASResolver, cmd.ExecuteRequest.GetRequest().GetActionDigest())
+		ar, err := cas.GetCacheResult(bzFiler.CASResolver, cmd.ExecuteRequest.GetRequest().GetActionDigest(), 2)
 		rts.actionCacheCheckEnd = stamp()
 		if err != nil {
 			// Only treat as an error if we didn't get NotFoundError. We still continue:
@@ -87,7 +87,7 @@ func fetchBazelCommandData(bzFiler *bzsnapshot.BzFiler, cmd *runner.Command, rts
 	log.Info("Fetching Bazel Action data from CAS server")
 	rts.actionFetchStart = stamp()
 	actionDigest := cmd.ExecuteRequest.GetRequest().GetActionDigest()
-	actionBytes, err := cas.ByteStreamRead(bzFiler.CASResolver, actionDigest)
+	actionBytes, err := cas.ByteStreamRead(bzFiler.CASResolver, actionDigest, 2)
 	if err != nil {
 		// NB: Important to return this error as-is
 		// CAS client function returns a particular error type if the read
@@ -111,7 +111,7 @@ func fetchBazelCommandData(bzFiler *bzsnapshot.BzFiler, cmd *runner.Command, rts
 	log.Info("Fetching Bazel Command data from CAS server")
 	rts.commandFetchStart = stamp()
 	commandDigest := action.GetCommandDigest()
-	commandBytes, err := cas.ByteStreamRead(bzFiler.CASResolver, commandDigest)
+	commandBytes, err := cas.ByteStreamRead(bzFiler.CASResolver, commandDigest, 2)
 	if err != nil {
 		// NB: Important to return this error as-is
 		// CAS client function returns a particular error type if the read
@@ -221,7 +221,7 @@ func postProcessBazel(filer snapshot.Filer,
 	// Add result to ActionCache. Errors non-fatal
 	if !cmd.ExecuteRequest.GetAction().GetDoNotCache() {
 		log.Info("Updating results in ActionCache")
-		_, err = cas.UpdateCacheResult(bzFiler.CASResolver, ad, ar)
+		_, err = cas.UpdateCacheResult(bzFiler.CASResolver, ad, ar, 2)
 		if err != nil {
 			log.Errorf("Error updating result to ActionCache: %s", err)
 		}
@@ -246,7 +246,7 @@ func writeFileToCAS(bzFiler *bzsnapshot.BzFiler, path string) (*remoteexecution.
 	sha := fmt.Sprintf("%x", sha256.Sum256(bytes))
 	digest := &remoteexecution.Digest{Hash: sha, SizeBytes: int64(len(bytes))}
 
-	err = cas.ByteStreamWrite(bzFiler.CASResolver, digest, bytes)
+	err = cas.ByteStreamWrite(bzFiler.CASResolver, digest, bytes, 2)
 	if err != nil {
 		return nil, fmt.Errorf("Error writing data to CAS server: %s", err)
 	}


### PR DESCRIPTION
Low-effort retries for bazel cas client libraries used in the workers. High-effort retries commented on in DPT-12747, but this at least buys us additional Resolve() calls if e.g. the first try Apiserver is down.