### PR TITLE
store/groupcache - use updated twitter/groupcache library that supports proper cache population

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,7 +65,7 @@
 [submodule "github.com/twitter/groupcache"]
 	path = vendor/github.com/twitter/groupcache
 	url = https://github.com/twitter/groupcache
-	branch = dgassaway/groupcache-put
+	branch = 2ace291295909af4da31eda5f01c5bc4077ef613
 [submodule "github.com/twitter/fuse"]
 	path = vendor/github.com/twitter/fuse
 	url = https://github.com/twitter/fuse

--- a/.gitmodules
+++ b/.gitmodules
@@ -65,7 +65,7 @@
 [submodule "github.com/twitter/groupcache"]
 	path = vendor/github.com/twitter/groupcache
 	url = https://github.com/twitter/groupcache
-	branch = 85fde1c5c36988481c30fc26605cd83f21cc94d1
+	branch = dgassaway/groupcache-put
 [submodule "github.com/twitter/fuse"]
 	path = vendor/github.com/twitter/fuse
 	url = https://github.com/twitter/fuse

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 language: go
 
 go:
-  - 1.10.5
+  - "1.10.x"
 
 git:
     submodules: false

--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -67,10 +67,12 @@ const (
 	GroupcacheWriteLatency_ms = "writeLatency_ms"
 
 	/*
-		Groupcache Underlying load metrics (cache miss loads)
+		Groupcache Underlying load metrics (cache misses)
 	*/
-	GroupcacheReadUnderlyingCounter    = "readUnderlyingCounter"
-	GroupcacheReadUnderlyingLatency_ms = "readUnderlyingLatency_ms"
+	GroupcacheReadUnderlyingCounter     = "readUnderlyingCounter"
+	GroupcacheReadUnderlyingLatency_ms  = "readUnderlyingLatency_ms"
+	GroupcacheWriteUnderlyingCounter    = "writeUnderlyingCounter"
+	GroupcacheWriteUnderlyingLatency_ms = "writeUnderlyingLatency_ms"
 
 	/*
 		Groupcache library - per-cache metrics (typical groupcache includes separate "main" and "hot" caches)
@@ -90,12 +92,17 @@ const (
 		Groupcache library - per-group metrics (overall metrics for a groupcache on a single Apiserver)
 	*/
 	GroupcacheGetCounter              = "cacheGetCounter"
+	GroupcachePutCounter              = "cachePutCounter"
 	GroupcacheHitCounter              = "cacheHitCounter"
 	GroupcacheLoadCounter             = "cacheLoadCounter"
+	GroupcacheStoreCounter            = "cacheStoreCounter"
 	GroupcacheIncomingRequestsCounter = "cacheIncomingRequestsCounter"
 	GroupcacheLocalLoadErrCounter     = "cacheLocalLoadErrCounter"
 	GroupcacheLocalLoadCounter        = "cacheLocalLoadCounter"
+	GroupcacheLocalStoreErrCounter    = "cacheLocalStoreErrCounter"
+	GroupcacheLocalStoreCounter       = "cacheLocalStoreCounter"
 	GroupcachePeerGetsCounter         = "cachePeerGetsCounter"
+	GroupcachePeerPutsCounter         = "cachePeerPutsCounter"
 	GroupcachPeerErrCounter           = "cachePeerErrCounter"
 
 	/*


### PR DESCRIPTION
Refactor groupcache Write as a groupcache "PutterFunc", see https://github.com/twitter-forks/groupcache/pull/1 for context.

groupcache submodule branch will be updated to a real commit when above PR lands.

Keep travis go version on latest minor release.