### PR TITLE
store/groupcache - don't drop sink SetBytes return value. update groupcache lib rev

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -61,7 +61,7 @@
 [submodule "github.com/twitter/groupcache"]
 	path = vendor/github.com/twitter/groupcache
 	url = https://github.com/twitter/groupcache
-	branch = dgassaway/cache-load-assert-check
+	branch = 677d001d35093016bf2514bc28bb93cd79709d43
 [submodule "github.com/twitter/fuse"]
 	path = vendor/github.com/twitter/fuse
 	url = https://github.com/twitter/fuse

--- a/.gitmodules
+++ b/.gitmodules
@@ -61,7 +61,7 @@
 [submodule "github.com/twitter/groupcache"]
 	path = vendor/github.com/twitter/groupcache
 	url = https://github.com/twitter/groupcache
-	branch = 3f0c8041e29b3d32eade74079a62f8fd7d9d9268
+	branch = dgassaway/cache-load-assert-check
 [submodule "github.com/twitter/fuse"]
 	path = vendor/github.com/twitter/fuse
 	url = https://github.com/twitter/fuse

--- a/snapshot/store/groupcache_store.go
+++ b/snapshot/store/groupcache_store.go
@@ -56,8 +56,7 @@ func MakeGroupcacheStore(underlying Store, cfg *GroupcacheConfig, ttlc *TTLConfi
 			if err != nil {
 				return err
 			}
-			dest.SetBytes(data)
-			return nil
+			return dest.SetBytes(data)
 		}),
 		groupcache.PutterFunc(func(ctx groupcache.Context, bundleName string, data []byte, ttl time.Duration) error {
 			log.Info("New bundle, write and populate cache: ", bundleName)


### PR DESCRIPTION
Groupcache GetterFunc was ignoring any error return values from SetBytes - pass them on instead of always nil.

Vendored groupcache lib and gitmodules will be updated when https://github.com/twitter/groupcache/pull/5 lands.

Tested groupcache functionality/propagation.