### PR TITLE
Log to stdout/err if task is killed for memory usage & set exitCode to 1

### DIFF
--- a/runner/execer/execer.go
+++ b/runner/execer/execer.go
@@ -20,6 +20,7 @@ type Command struct {
 	Dir     string
 	Stdout  io.Writer
 	Stderr  io.Writer
+	MemCh   chan struct{}
 	tags.LogTags
 }
 

--- a/runner/execer/execer.go
+++ b/runner/execer/execer.go
@@ -20,7 +20,7 @@ type Command struct {
 	Dir     string
 	Stdout  io.Writer
 	Stderr  io.Writer
-	MemCh   chan struct{}
+	MemCh   chan ProcessStatus
 	tags.LogTags
 }
 

--- a/runner/execer/os/easy_test.go
+++ b/runner/execer/os/easy_test.go
@@ -118,7 +118,7 @@ func TestMemCap(t *testing.T) {
 	// Command to increase memory by 1MB every .1s up to 5s.
 	// Creates a bash process and under that a python process. They should both contribute to MemUsage.
 	str := `import time; exec("x=[]\nfor i in range(50):\n x.append(' ' * 1024*1024)\n time.sleep(.1)")`
-	memCh := make(chan struct{})
+	memCh := make(chan execer.ProcessStatus)
 	cmd := execer.Command{
 		Argv: []string{"python", "-c", str},
 		LogTags: tags.LogTags{

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -121,7 +121,7 @@ type osProcess struct {
 //
 // Periodically check to make sure memory constraints are respected,
 // and clean up after ourselves when the process has completed
-func (e *osExecer) monitorMem(p *osProcess, memCh chan struct{}) {
+func (e *osExecer) monitorMem(p *osProcess, memCh chan execer.ProcessStatus) {
 	pid := p.cmd.Process.Pid
 	pgid, err := syscall.Getpgid(pid)
 	if err != nil {
@@ -179,11 +179,12 @@ func (e *osExecer) monitorMem(p *osProcess, memCh chan struct{}) {
 						"taskID": p.TaskID,
 					}).Info(msg)
 				p.result = &execer.ProcessStatus{
-					State: execer.FAILED,
-					Error: msg,
+					State:    execer.COMPLETE,
+					Error:    msg,
+					ExitCode: 1,
 				}
 				if memCh != nil {
-					memCh <- struct{}{}
+					memCh <- *p.result
 				}
 				p.mutex.Unlock()
 				p.Abort()

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -182,7 +182,9 @@ func (e *osExecer) monitorMem(p *osProcess, memCh chan struct{}) {
 					State: execer.FAILED,
 					Error: msg,
 				}
-				memCh <- struct{}{}
+				if memCh != nil {
+					memCh <- struct{}{}
+				}
 				p.mutex.Unlock()
 				p.Abort()
 				return

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -372,8 +372,8 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 		return runner.TimeoutStatus(id,
 			tags.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID, Tag: cmd.Tag})
 	case st = <-memCh:
-		stdout.Write([]byte(fmt.Sprintf("\n\n%s\n\nFAILED\n\nCmd exceeded MemoryCap, aborting %v", marker, cmd.String())))
-		stderr.Write([]byte(fmt.Sprintf("\n\n%s\n\nFAILED\n\nCmd exceeded MemoryCap, aborting %v", marker, cmd.String())))
+		stdout.Write([]byte(fmt.Sprintf("\n\n%s\n\nFAILED\n\n%v", marker, st.Error)))
+		stderr.Write([]byte(fmt.Sprintf("\n\n%s\n\nFAILED\n\n%v", marker, st.Error)))
 		log.WithFields(
 			log.Fields{
 				"cmd":    cmd.String(),

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -376,16 +376,20 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 		stderr.Write([]byte(fmt.Sprintf("\n\n%s\n\nFAILED\n\n%v", marker, st.Error)))
 		log.WithFields(
 			log.Fields{
-				"cmd":    cmd.String(),
-				"tag":    cmd.Tag,
-				"jobID":  cmd.JobID,
-				"taskID": cmd.TaskID,
+				"runID":    id,
+				"cmd":      cmd.String(),
+				"tag":      cmd.Tag,
+				"jobID":    cmd.JobID,
+				"taskID":   cmd.TaskID,
+				"status":   st,
+				"checkout": co.Path(),
 			}).Infof("Cmd exceeded MemoryCap, aborting %v", cmd.String())
 	case st = <-processCh:
 		// Process has completed
 		log.WithFields(
 			log.Fields{
 				"runID":    id,
+				"cmd":      cmd.String(),
 				"tag":      cmd.Tag,
 				"jobID":    cmd.JobID,
 				"taskID":   cmd.TaskID,

--- a/runner/runners/single_test.go
+++ b/runner/runners/single_test.go
@@ -129,9 +129,9 @@ func TestMemCap(t *testing.T) {
 		t.Fatalf(err.Error())
 	} else if len(runs) != 1 {
 		t.Fatalf("Expected a single COMPLETE run, got %v", len(runs))
-	} else if runs[0].ExitCode != 1 {
+	} else if runs[0].ExitCode != 1 || !strings.Contains(runs[0].Error, "Cmd exceeded MemoryCap, aborting") {
 		status, _, err := r.StatusAll()
-		t.Fatalf("Expected result with COMPLETE and an exit code of 1, got: %v -- status %v -- err %v", runs, status, err)
+		t.Fatalf("Expected result with error message mentioning MemoryCap & an exit code of 1, got: %v -- status %v err %v -- exitCode %v", runs, status, err, runs[0].ExitCode)
 	}
 }
 

--- a/runner/runners/single_test.go
+++ b/runner/runners/single_test.go
@@ -122,14 +122,16 @@ func TestMemCap(t *testing.T) {
 
 	query := runner.Query{
 		AllRuns: true,
-		States:  runner.MaskForState(runner.FAILED),
+		States:  runner.MaskForState(runner.COMPLETE),
 	}
 	// Travis may be slow, wait a super long time? This may also be necessary due to slow debug output from os_execer? TBD.
 	if runs, _, err := r.Query(query, runner.Wait{Timeout: 10 * time.Second}); err != nil {
 		t.Fatalf(err.Error())
-	} else if len(runs) != 1 || !strings.Contains(runs[0].Error, "MemoryCap") {
+	} else if len(runs) != 1 {
+		t.Fatalf("Expected a single COMPLETE run, got %v", len(runs))
+	} else if runs[0].ExitCode != 1 {
 		status, _, err := r.StatusAll()
-		t.Fatalf("Expected result with FAILURE and matching err string, got: %v -- status %v -- err %v", runs, status, err)
+		t.Fatalf("Expected result with COMPLETE and an exit code of 1, got: %v -- status %v -- err %v", runs, status, err)
 	}
 }
 

--- a/runner/status.go
+++ b/runner/status.go
@@ -78,7 +78,7 @@ type RunStatus struct {
 	SnapshotID string
 	ExitCode   int
 
-	// Only valid if State == (FAILED || BADREQUEST || ABORTED)
+	// Only valid if State == (COMPLETE || FAILED || BADREQUEST || ABORTED)
 	Error string
 
 	tags.LogTags


### PR DESCRIPTION
Problem

Tasks that exceeded the memory limit imposed by a bounded os.osExecer provided no useful indication to clients on the cause of their task failure.

Solution

Log to stdout/err if a task exceeds the memory limit, and set exit code to 1 to indicate failure.

Result

Stdout/err will have a trailing message stating that the task failed due to memory constraints.
