### PR TITLE
Fix memory watcher & write to stdlog in addition to stdout/err

### DIFF
--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -232,6 +232,8 @@ func (e *osExecer) monitorMem(p *osProcess, memCh chan execer.ProcessStatus) {
 // Query for all sets of (pid, pgid, ppid, rss). Given a pid, find all processes with pid as its pgid or ppid.
 // Given this list of pids, find all processes with a pgid or ppid in that set, and modify the set in place.
 // From there, sum the memory of all processes in aforementioned set.
+// TODO: Python script is hard to test and probably non-performant compared to a native Go solution.
+// 		 Refactor into unit-testable Go func.
 func (e *osExecer) memUsage(pid int) (execer.Memory, error) {
 	str := `
 PID=%d

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -247,13 +247,13 @@ total=0
 for line in \"$PSLIST\".split(';'):
   pid, pgid, ppid, rss = tuple(line.split())
   all_processes[pid] = {'pgid': pgid, 'ppid': ppid, 'rss': rss}
-  process_groups.get(pgid, []).append(pid)
-  parent_processes.get(ppid, {}).append(pid)
+  process_groups.setdefault(pgid, []).append(pid)
+  parent_processes.setdefault(ppid, []).append(pid)
   if pid == \"$PID\":
     proc_group_id = pgid
 
 # Add all processes from pid's process group to related_processes
-for pid in process_groups[proc_group_id]:
+for pid in process_groups.setdefault(proc_group_id, []):
   related_processes[pid] = all_processes[pid]
 
 # Add children processes of related_processes to children list

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -229,11 +229,12 @@ func (e *osExecer) monitorMem(p *osProcess, memCh chan execer.ProcessStatus) {
 	}
 }
 
-// Query for all sets of (pid, pgid, rss). Given a pid, find its associated pgid.
-// From there, sum the memory of all processes with the same pgid.
+// Query for all sets of (pid, pgid, ppid, rss). Given a pid, find all processes with pid as its pgid or ppid.
+// Given this list of pids, find all processes with a pgid or ppid in that set, and modify the set in place.
+// From there, sum the memory of all processes in aforementioned set.
 func (e *osExecer) memUsage(pid int) (execer.Memory, error) {
 	str := `
-PID=%s
+PID=%d
 PSLIST=$(ps -e -o pid= -o pgid= -o ppid= -o rss= | tr '\n' ';' | sed 's,;$,,')
 echo "
 all_processes=dict()

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -355,12 +355,14 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 	case <-abortCh:
 		stdout.Write([]byte(fmt.Sprintf("\n\n%s\n\nFAILED\n\nTask aborted: %v", marker, cmd.String())))
 		stderr.Write([]byte(fmt.Sprintf("\n\n%s\n\nFAILED\n\nTask aborted: %v", marker, cmd.String())))
+		stdlog.Write([]byte(fmt.Sprintf("\n\n%s\n\nFAILED\n\nTask aborted: %v", marker, cmd.String())))
 		p.Abort()
 		return runner.AbortStatus(id,
 			tags.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID, Tag: cmd.Tag})
 	case <-timeoutCh:
 		stdout.Write([]byte(fmt.Sprintf("\n\n%s\n\nFAILED\n\nTask exceeded timeout %v: %v", marker, cmd.Timeout, cmd.String())))
 		stderr.Write([]byte(fmt.Sprintf("\n\n%s\n\nFAILED\n\nTask exceeded timeout %v: %v", marker, cmd.Timeout, cmd.String())))
+		stdlog.Write([]byte(fmt.Sprintf("\n\n%s\n\nFAILED\n\nTask exceeded timeout %v: %v", marker, cmd.Timeout, cmd.String())))
 		p.Abort()
 		log.WithFields(
 			log.Fields{
@@ -374,6 +376,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 	case st = <-memCh:
 		stdout.Write([]byte(fmt.Sprintf("\n\n%s\n\nFAILED\n\n%v", marker, st.Error)))
 		stderr.Write([]byte(fmt.Sprintf("\n\n%s\n\nFAILED\n\n%v", marker, st.Error)))
+		stdlog.Write([]byte(fmt.Sprintf("\n\n%s\n\nFAILED\n\n%v", marker, st.Error)))
 		log.WithFields(
 			log.Fields{
 				"runID":    id,


### PR DESCRIPTION
Problem

1. Memory watcher wasn't including some processes that should've been in the summation of memory usage, only processes in the same process group as the watched process. This excluded processes with parent processes in the process group of the watched process, but spawned into their own process group.
2. After exceeding memory cap, error message was written to stdout & stderr, but not stdlog (combination of stdout & stderr)

Solution

1. Revamp memory watcher script to include aforementioned processes.
2. Write error message to stdlog in addition to stdout/err

Result

More accurate memory watching & error message now written to stdlog as well.
