### PR TITLE
snapshot/store - write content length for http, groupcache store writes

### DIFF
--- a/snapshot/store/groupcache_store.go
+++ b/snapshot/store/groupcache_store.go
@@ -19,7 +19,7 @@ type PeerFetcher interface {
 	Fetch() ([]cluster.Node, error)
 }
 
-//TODO: we should consider extending contexts in groupcache lib further to:
+// TODO: we should consider extending contexts in groupcache lib further to:
 // 1) control hot cache population rate deterministically (currently hardcoded at 10%)
 // 2) add more advanced caching behaviors like propagation to peer caches,
 //	  or populate cache and skip underlying store write, etc.
@@ -144,7 +144,6 @@ func (s *groupcacheStore) Exists(name string) (bool, error) {
 }
 
 func (s *groupcacheStore) Write(name string, data io.Reader, ttl *TTLValue) error {
-	log.Info("Write() checking for cached bundle: ", name)
 	defer s.stat.Latency(stats.GroupcacheWriteLatency_ms).Time().Stop()
 	s.stat.Counter(stats.GroupcacheWriteCounter).Inc(1)
 
@@ -157,6 +156,8 @@ func (s *groupcacheStore) Write(name string, data io.Reader, ttl *TTLValue) erro
 	copy(c, b)
 
 	d := GetDurationTTL(ttl)
+
+	log.Infof("Write() bundle %s: length: %d ttl: %s", name, len(b), ttl)
 	if err := s.cache.Put(nil, name, c, d); err != nil {
 		return err
 	}

--- a/snapshot/store/http_store.go
+++ b/snapshot/store/http_store.go
@@ -108,7 +108,6 @@ func (s *httpStore) Write(name string, data io.Reader, ttl *TTLValue) error {
 		return errors.New("'/' not allowed in name when writing bundles.")
 	}
 	uri := s.rootURI + name
-	log.Infof("Writing %s", uri)
 
 	post := func() (*http.Response, error) {
 		req, err := http.NewRequest("POST", uri, data)
@@ -122,7 +121,7 @@ func (s *httpStore) Write(name string, data io.Reader, ttl *TTLValue) error {
 		if ttl.TTLKey != "" {
 			req.Header[ttl.TTLKey] = []string{ttl.TTL.Format(time.RFC1123)}
 		}
-		log.Infof("Write header: %s %v", uri, req.Header)
+		log.Infof("Writing %s: length: %d header: %v", uri, req.ContentLength, req.Header)
 		return s.client.Do(req)
 	}
 


### PR DESCRIPTION
Permit manual tracing of written content sizes in apiserver.