### PR TITLE
add lots of debug logging to investigate flakiness

### DIFF
--- a/bazel/cas/service.go
+++ b/bazel/cas/service.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"sync"
 	"time"
-	// "runtime/debug"
 	"github.com/golang/protobuf/proto"
 	log "github.com/sirupsen/logrus"
 	remoteexecution "github.com/twitter/scoot/bazel/remoteexecution"
@@ -497,10 +496,8 @@ func (s *casServer) Read(req *bytestream.ReadRequest, ser bytestream.ByteStream_
 // store.Stores do not support partial Writes, and neither does our implementation.
 // We can support partial Write by keeping buffers for inflight requests in the casServer.
 // When the entire Write is buffered, we can Write to the Store and return a response with the result.
-// NOTE We also so not currently attempt any resolution between multiple client UUIDs writing the same resource
+// NOTE We also do not currently attempt any resolution between multiple client UUIDs writing the same resource
 func (s *casServer) Write(ser bytestream.ByteStream_WriteServer) error {
-
-	// debug.PrintStack()
 
 	var intId = rand.Intn(200000)
 


### PR DESCRIPTION
*I'm not sure if this change is something Scoot would want to do differently.*

### Problem

When running a local cluster with `go run ./binaries/setup-cloud-scoot/main.go --strategy local.local` to run pants against, we uncovered some flakiness, which was resolved in pants with pantsbuild/pants#7422. We investigated that by pairing timestamped logs from pants (which are being done in pantsbuild/pants#7536) with timestamped logs from scoot when uploading files (from this change).

*Explain the context and why you're making that change. What is
the problem you're trying to solve? In some cases there is not a
problem and this can be thought of being the motivation for your change.*

### Solution

- Add some info to the debug logs in the grpc cas write method, including:
  - timestamps
  - a randomly assigned request id

*Describe the modifications you've done.*

### Result

CAS writes via Scoot and any flakiness around them are easier to debug!

*What will change as a result of your pull request? Note that sometimes
this section is unnecessary because it is self-explanatory based on
the solution.*