### PR TITLE
runner/runners - RunnerID and small debug fixes

### DIFF
--- a/binaries/bzutil/main.go
+++ b/binaries/bzutil/main.go
@@ -43,6 +43,7 @@ var supportedCommands map[string]bool = map[string]bool{
 
 func main() {
 	log.AddHook(hooks.NewContextHook())
+	log.SetLevel(log.InfoLevel)
 
 	// TODO additional commands
 	// - upload Directory (tbd)
@@ -57,7 +58,7 @@ func main() {
 	uploadOutputFiles := uploadCommand.String("output_files", "", "Output files to ingest as comma-separated list: '/file1,/dir/file2'")
 	uploadOutputDirs := uploadCommand.String("output_dirs", "", "Output dirs to ingest as comma-separated list: '/dir'")
 	uploadPlatformProps := uploadCommand.String("platform_props", "", "comma-separated command platoform properties, i.e. \"key1=val1,key2=val2\"")
-	uploadJson := uploadCommand.Bool("json", false, "Print command digest as JSON")
+	uploadJson := uploadCommand.Bool("json", false, "Print command digest as JSON to stdout")
 
 	// Upload Action
 	uploadAction := flag.NewFlagSet(uploadActionStr, flag.ExitOnError)
@@ -65,20 +66,20 @@ func main() {
 	actionCommandDigest := uploadAction.String("command", "", "Command digest as '<hash>/<size>'")
 	actionRootDigest := uploadAction.String("input_root", "", "Input root digest as '<hash>/<size>'")
 	actionNoCache := uploadAction.Bool("no_cache", false, "Flag to prevent result caching")
-	actionJson := uploadAction.Bool("json", false, "Print action digest as JSON")
+	actionJson := uploadAction.Bool("json", false, "Print action digest as JSON to stdout")
 
 	// Execute
 	execCommand := flag.NewFlagSet(execCmdStr, flag.ExitOnError)
 	execAddr := execCommand.String("grpc_addr", scootapi.DefaultSched_GRPC, "'host:port' of grpc Exec server")
 	execActionDigest := execCommand.String("action", "", "Action digest as '<hash>/<size>'")
 	execSkipCache := execCommand.Bool("skip_cache", false, "Skip checking for cached results")
-	execJson := execCommand.Bool("json", false, "Print operation as JSON")
+	execJson := execCommand.Bool("json", false, "Print operation as JSON to stdout")
 
 	// Get Operation
 	getCommand := flag.NewFlagSet(getOpCmdStr, flag.ExitOnError)
 	getAddr := getCommand.String("grpc_addr", scootapi.DefaultSched_GRPC, "'host:port' of grpc Exec server")
 	getName := getCommand.String("name", "", "Operation name to query")
-	getJson := getCommand.Bool("json", false, "Print operation as JSON")
+	getJson := getCommand.Bool("json", false, "Print operation as JSON to stdout")
 
 	// Parse input flags
 	if len(os.Args) < 2 {

--- a/binaries/bzutil/main.go
+++ b/binaries/bzutil/main.go
@@ -43,7 +43,7 @@ var supportedCommands map[string]bool = map[string]bool{
 
 func main() {
 	log.AddHook(hooks.NewContextHook())
-	log.SetLevel(log.InfoLevel)
+	log.SetLevel(log.InfoLevel) // default, can be flag overridden
 
 	// TODO additional commands
 	// - upload Directory (tbd)
@@ -59,6 +59,7 @@ func main() {
 	uploadOutputDirs := uploadCommand.String("output_dirs", "", "Output dirs to ingest as comma-separated list: '/dir'")
 	uploadPlatformProps := uploadCommand.String("platform_props", "", "comma-separated command platoform properties, i.e. \"key1=val1,key2=val2\"")
 	uploadJson := uploadCommand.Bool("json", false, "Print command digest as JSON to stdout")
+	uploadLogLevel := uploadCommand.String("log_level", "", "Log everything at this level and above (error|info|debug)")
 
 	// Upload Action
 	uploadAction := flag.NewFlagSet(uploadActionStr, flag.ExitOnError)
@@ -67,6 +68,7 @@ func main() {
 	actionRootDigest := uploadAction.String("input_root", "", "Input root digest as '<hash>/<size>'")
 	actionNoCache := uploadAction.Bool("no_cache", false, "Flag to prevent result caching")
 	actionJson := uploadAction.Bool("json", false, "Print action digest as JSON to stdout")
+	actionLogLevel := uploadAction.String("log_level", "", "Log everything at this level and above (error|info|debug)")
 
 	// Execute
 	execCommand := flag.NewFlagSet(execCmdStr, flag.ExitOnError)
@@ -74,12 +76,14 @@ func main() {
 	execActionDigest := execCommand.String("action", "", "Action digest as '<hash>/<size>'")
 	execSkipCache := execCommand.Bool("skip_cache", false, "Skip checking for cached results")
 	execJson := execCommand.Bool("json", false, "Print operation as JSON to stdout")
+	execLogLevel := execCommand.String("log_level", "", "Log everything at this level and above (error|info|debug)")
 
 	// Get Operation
 	getCommand := flag.NewFlagSet(getOpCmdStr, flag.ExitOnError)
 	getAddr := getCommand.String("grpc_addr", scootapi.DefaultSched_GRPC, "'host:port' of grpc Exec server")
 	getName := getCommand.String("name", "", "Operation name to query")
 	getJson := getCommand.Bool("json", false, "Print operation as JSON to stdout")
+	getLogLevel := getCommand.String("log_level", "", "Log everything at this level and above (error|info|debug)")
 
 	// Parse input flags
 	if len(os.Args) < 2 {
@@ -106,25 +110,41 @@ func main() {
 		if len(uploadArgv) == 0 {
 			log.Fatalf("Argv required for %s - will interpret all non-flag arguments as Argv", uploadCmdStr)
 		}
+		parseAndSetLevel(*uploadLogLevel)
 		uploadBzCommand(uploadArgv, *uploadAddr, *uploadEnv, *uploadOutputFiles, *uploadOutputDirs, *uploadPlatformProps, *uploadJson)
 	} else if uploadAction.Parsed() {
 		if *actionCommandDigest == "" || *actionRootDigest == "" {
 			log.Fatalf("command and input_root required for %s", execCmdStr)
 		}
+		parseAndSetLevel(*actionLogLevel)
 		uploadBzAction(*actionAddr, *actionCommandDigest, *actionRootDigest, *actionNoCache, *actionJson)
 	} else if execCommand.Parsed() {
 		if *execActionDigest == "" {
 			log.Fatalf("action digest required for %s", execCmdStr)
 		}
+		parseAndSetLevel(*execLogLevel)
 		execute(*execAddr, *execActionDigest, *execSkipCache, *execJson)
 	} else if getCommand.Parsed() {
 		if *getName == "" {
 			log.Fatalf("name required for %s", getOpCmdStr)
 		}
+		parseAndSetLevel(*getLogLevel)
 		getOperation(*getAddr, *getName, *getJson)
 	} else {
 		log.Fatal("No expected commands parsed")
 	}
+}
+
+func parseAndSetLevel(logLevel string) {
+	if logLevel == "" {
+		return
+	}
+	level, err := log.ParseLevel(logLevel)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	log.SetLevel(level)
 }
 
 func uploadBzCommand(cmdArgs []string, casAddr, env, outputFilesStr, outputDirsStr, platformProps string, uploadJson bool) {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -88,6 +88,18 @@ func MakeRunTypeMap() RunTypeMap {
 	return make(map[RunType]snapshot.FilerAndInitDoneCh)
 }
 
+// Can be used to initialize a Runner with specific identifying information
+type RunnerID struct {
+	ID string
+}
+
+// Return a string representation of a RunnerID
+func (rID RunnerID) String() string {
+	return rID.ID
+}
+
+var EmptyID RunnerID = RunnerID{ID: ""}
+
 // Service allows starting/abort'ing runs and checking on their status.
 type Service interface {
 	Controller

--- a/runner/runners/bazel.go
+++ b/runner/runners/bazel.go
@@ -270,6 +270,7 @@ func writeFileToCAS(bzFiler *bzsnapshot.BzFiler, path string) (*remoteexecution.
 	if err != nil {
 		return nil, fmt.Errorf("Error writing data to CAS server: %s", err)
 	}
+	log.Infof("Wrote file to CAS: %s as %s", path, digest)
 
 	return digest, nil
 }

--- a/runner/runners/polling_test.go
+++ b/runner/runners/polling_test.go
@@ -17,7 +17,7 @@ func setupPoller() (*execers.SimExecer, *ChaosRunner, runner.Service) {
 	ex := execers.NewSimExecer()
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeInvalidFiler(), IDC: nil}
-	single := NewSingleRunner(ex, filerMap, NewNullOutputCreator(), tmp, nil)
+	single := NewSingleRunner(ex, filerMap, NewNullOutputCreator(), tmp, nil, runner.EmptyID)
 	chaos := NewChaosRunner(single)
 	var nower runner.StatusQueryNower
 	nower = chaos

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -74,8 +74,14 @@ to complete successfully before serving requests.
 @param: stats - the stats receiver the queue will use when reporting its metrics
 */
 func NewQueueRunner(
-	exec execer.Execer, filerMap runner.RunTypeMap, output runner.OutputCreator, tmp *temp.TempDir, capacity int, stat stats.StatsReceiver) runner.Service {
-
+	exec execer.Execer,
+	filerMap runner.RunTypeMap,
+	output runner.OutputCreator,
+	tmp *temp.TempDir,
+	capacity int,
+	stat stats.StatsReceiver,
+	rID runner.RunnerID,
+) runner.Service {
 	if stat == nil {
 		stat = stats.NilStatsReceiver()
 	}
@@ -89,7 +95,7 @@ func NewQueueRunner(
 	}
 
 	statusManager := NewStatusManager(history)
-	inv := NewInvoker(exec, filerMap, output, tmp, stat)
+	inv := NewInvoker(exec, filerMap, output, tmp, stat, rID)
 
 	controller := &QueueController{
 		statusManager: statusManager,
@@ -149,8 +155,14 @@ func NewQueueRunner(
 }
 
 func NewSingleRunner(
-	exec execer.Execer, filerMap runner.RunTypeMap, output runner.OutputCreator, tmp *temp.TempDir, stat stats.StatsReceiver) runner.Service {
-	return NewQueueRunner(exec, filerMap, output, tmp, 0, stat)
+	exec execer.Execer,
+	filerMap runner.RunTypeMap,
+	output runner.OutputCreator,
+	tmp *temp.TempDir,
+	stat stats.StatsReceiver,
+	rID runner.RunnerID,
+) runner.Service {
+	return NewQueueRunner(exec, filerMap, output, tmp, 0, stat, rID)
 }
 
 // QueueController maintains a queue of commands to run (up to capacity).

--- a/runner/runners/queue_test.go
+++ b/runner/runners/queue_test.go
@@ -222,7 +222,7 @@ func setup(capacity int, interval time.Duration, t *testing.T) *env {
 
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeInvalidFilerUpdater(updater), IDC: nil}
-	r := NewQueueRunner(sim, filerMap, outputCreator, tmpDir, capacity, nil)
+	r := NewQueueRunner(sim, filerMap, outputCreator, tmpDir, capacity, nil, runner.EmptyID)
 
 	return &env{sim: sim, r: r, u: updater, uc: &updateCount}
 }

--- a/runner/runners/setup.go
+++ b/runner/runners/setup.go
@@ -1,6 +1,10 @@
 package runners
 
 import (
+	"fmt"
+	"math/rand"
+	"os"
+
 	"github.com/twitter/scoot/common/stats"
 	"github.com/twitter/scoot/ice"
 	"github.com/twitter/scoot/runner"
@@ -23,7 +27,10 @@ func (m module) Install(b *ice.MagicBag) {
 			return execers.MakeSimExecerInterceptor(execers.NewSimExecer(), osexec.NewBoundedExecer(m, s))
 		},
 		func() runner.RunnerID {
-			return runner.EmptyID
+			// suitable local testing purposes, but a production implementation would supply a unique ID
+			hostname, _ := os.Hostname()
+			hostname = fmt.Sprintf("%s-%d", hostname, rand.Intn(10000))
+			return runner.RunnerID{ID: hostname}
 		},
 		NewSingleRunner,
 	)

--- a/runner/runners/setup.go
+++ b/runner/runners/setup.go
@@ -3,6 +3,7 @@ package runners
 import (
 	"github.com/twitter/scoot/common/stats"
 	"github.com/twitter/scoot/ice"
+	"github.com/twitter/scoot/runner"
 	"github.com/twitter/scoot/runner/execer"
 	"github.com/twitter/scoot/runner/execer/execers"
 	osexec "github.com/twitter/scoot/runner/execer/os"
@@ -20,6 +21,9 @@ func (m module) Install(b *ice.MagicBag) {
 	b.PutMany(
 		func(m execer.Memory, s stats.StatsReceiver) execer.Execer {
 			return execers.MakeSimExecerInterceptor(execers.NewSimExecer(), osexec.NewBoundedExecer(m, s))
+		},
+		func() runner.RunnerID {
+			return runner.EmptyID
 		},
 		NewSingleRunner,
 	)

--- a/runner/runners/single_test.go
+++ b/runner/runners/single_test.go
@@ -115,7 +115,7 @@ func TestMemCap(t *testing.T) {
 	e := os_execer.NewBoundedExecer(execer.Memory(10*1024*1024), stats.NilStatsReceiver())
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeNoopFiler(tmp.Dir), IDC: nil}
-	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), tmp, nil)
+	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), tmp, nil, runner.EmptyID)
 	if _, err := r.Run(cmd); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -143,7 +143,7 @@ func TestStats(t *testing.T) {
 	e := execers.NewSimExecer()
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeNoopFiler(tmp.Dir), IDC: nil}
-	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), tmp, stat)
+	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), tmp, stat, runner.EmptyID)
 	if _, err := r.Run(cmd); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -181,7 +181,7 @@ func TestTimeout(t *testing.T) {
 	e := execers.NewSimExecer()
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeNoopFiler(tmp.Dir), IDC: nil}
-	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), tmp, stat)
+	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), tmp, stat, runner.EmptyID)
 	if _, err := r.Run(cmd); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -222,7 +222,7 @@ func newRunner() (runner.Service, *execers.SimExecer) {
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeInvalidFiler(), IDC: nil}
 
-	r := NewSingleRunner(sim, filerMap, outputCreator, tmpDir, nil)
+	r := NewSingleRunner(sim, filerMap, outputCreator, tmpDir, nil, runner.EmptyID)
 	return r, sim
 }
 

--- a/sched/scheduler/stateful_scheduler_test.go
+++ b/sched/scheduler/stateful_scheduler_test.go
@@ -269,7 +269,7 @@ func Test_StatefulScheduler_TaskGetsMarkedCompletedAfterMaxRetriesFailedRuns(t *
 		ex.ExecError = errors.New("Test - failed to exec")
 		filerMap := runner.MakeRunTypeMap()
 		filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeInvalidFiler(), IDC: nil}
-		return runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), tmp, nil)
+		return runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), tmp, nil, runner.EmptyID)
 	}
 
 	s := makeStatefulSchedulerDeps(deps)
@@ -729,7 +729,7 @@ func getDepsWithSimWorker() (*schedulerDeps, []*execers.SimExecer) {
 			ex := execers.NewSimExecer()
 			filerMap := runner.MakeRunTypeMap()
 			filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeInvalidFiler(), IDC: nil}
-			runner := runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), tmp, nil)
+			runner := runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), tmp, nil, runner.EmptyID)
 			return runner
 		},
 		config: SchedulerConfig{

--- a/sched/worker/workers/makers.go
+++ b/sched/worker/workers/makers.go
@@ -22,7 +22,7 @@ func MakeDoneWorker(tmp *temp.TempDir) runner.Service {
 	ex := execers.NewDoneExecer()
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeInvalidFiler(), IDC: nil}
-	r := runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), tmp, nil)
+	r := runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), tmp, nil, runner.EmptyID)
 	chaos := runners.NewChaosRunner(r)
 	chaos.SetDelay(time.Duration(50) * time.Millisecond)
 	return chaos
@@ -33,5 +33,5 @@ func MakeSimWorker(tmp *temp.TempDir) runner.Service {
 	ex := execers.NewSimExecer()
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeInvalidFiler(), IDC: nil}
-	return runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), tmp, nil)
+	return runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), tmp, nil, runner.EmptyID)
 }


### PR DESCRIPTION
- Add runner.RunnerID struct for passing some IDing info during Runner creation.
- Use RunnerID in remexec ExecutedOperationMetadata.Worker.
- Print remexec ingested file/dir digests.
- Fix stderr printing in bzutil.

Example of runner id info in remexec task:

> 			ExecutionMetadata:
> 				Worker: smf1/dgassaway/devel/scoot-worker/10
> 				QueueLatency: 467ms
> 				WorkerTotal: 271ms
> 				InputFetch: 33ms
> 				Execution: 44ms
> 				OutputUpload: 194ms  sourceLine="bzutil/main.go:272"