### PR TITLE
Rcouto/dpt 15121/create tmpdir if dne

### DIFF
--- a/runner/runners/local_output.go
+++ b/runner/runners/local_output.go
@@ -56,6 +56,12 @@ func NewHttpOutputCreator(tmp *temp.TempDir, httpUri string) (HttpOutputCreator,
 // Create a new Output that writes to local fs.
 // Note: id should not have leading or trailing slashes.
 func (s *localOutputCreator) Create(id string) (runner.Output, error) {
+	if _, err := os.Stat(s.tmp.Dir); os.IsNotExist(err) {
+		err = os.MkdirAll(s.tmp.Dir, os.ModePerm)
+		if err != nil {
+			return nil, err
+		}
+	}
 	f, err := s.tmp.TempFile(id)
 	if err != nil {
 		return nil, err

--- a/runner/runners/local_output_test.go
+++ b/runner/runners/local_output_test.go
@@ -21,6 +21,7 @@ func TestLocalOutputCreator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create temp dir: %v", err)
 	}
+	defer os.RemoveAll(td.Dir)
 	h, err := NewHttpOutputCreator(td, "")
 	if err != nil {
 		t.Fatalf("Unable to create output creator: %v", err)
@@ -39,6 +40,7 @@ func TestLocalOutputCreatorNonexistentTempDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create temp dir: %v", err)
 	}
+	defer os.RemoveAll(td.Dir)
 	h, err := NewHttpOutputCreator(td, "")
 	if err != nil {
 		t.Fatalf("Unable to create output creator: %v", err)

--- a/runner/runners/local_output_test.go
+++ b/runner/runners/local_output_test.go
@@ -1,0 +1,60 @@
+package runners
+
+import (
+	"os"
+	"testing"
+
+	"github.com/twitter/scoot/common/log/hooks"
+	"github.com/twitter/scoot/os/temp"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func init() {
+	log.AddHook(hooks.NewContextHook())
+	logrusLevel, _ := log.ParseLevel("debug")
+	log.SetLevel(logrusLevel)
+}
+
+func TestLocalOutputCreator(t *testing.T) {
+	td, err := temp.TempDirDefault()
+	if err != nil {
+		t.Fatalf("Unable to create temp dir: %v", err)
+	}
+	h, err := NewHttpOutputCreator(td, "")
+	if err != nil {
+		t.Fatalf("Unable to create output creator: %v", err)
+	}
+	o, err := h.Create("test-id")
+	if err != nil {
+		t.Fatalf("Error creating output: %v", err)
+	}
+	if _, err := os.Stat(o.AsFile()); os.IsNotExist(err) {
+		t.Fatalf("Didn't create output, file %v does not exist. Err: %v", o.AsFile(), err)
+	}
+}
+
+func TestLocalOutputCreatorNonexistentTempDir(t *testing.T) {
+	td, err := temp.TempDirDefault()
+	if err != nil {
+		t.Fatalf("Unable to create temp dir: %v", err)
+	}
+	h, err := NewHttpOutputCreator(td, "")
+	if err != nil {
+		t.Fatalf("Unable to create output creator: %v", err)
+	}
+	err = os.RemoveAll(td.Dir)
+	if err != nil {
+		t.Fatalf("Unable to remove temp dir %v: %v", td.Dir, err)
+	}
+	if _, err := os.Stat(td.Dir); !os.IsNotExist(err) {
+		t.Fatalf("Expected %v to not exist after removal. Err: %v", td.Dir, err)
+	}
+	o, err := h.Create("test-id") // should recreate td.Dir
+	if err != nil {
+		t.Fatalf("Error creating output: %v", err)
+	}
+	if _, err := os.Stat(o.AsFile()); os.IsNotExist(err) {
+		t.Fatalf("Didn't create output, file %v does not exist. Err: %v", o.AsFile(), err)
+	}
+}


### PR DESCRIPTION
Problem

The dir used by the localOutputCreator to write stdout/err to can be deleted, leaving workers unable to create output.
 
Solution

Recreate the tempdir and all nonexistent parents in the case that it doesn't exist
