### PR TITLE
sched/scheduler - advance to next scheduler loop if there is pending work to do

### DIFF
--- a/binaries/bzutil/main.go
+++ b/binaries/bzutil/main.go
@@ -212,6 +212,8 @@ func uploadBzCommand(cmdArgs []string, casAddr, env, outputFilesStr, outputDirsS
 			log.Fatalf("Error converting digest to JSON: %v", err)
 		}
 		fmt.Printf("%s\n", b)
+	} else {
+		fmt.Printf("%s/%d\n", digest.GetHash(), digest.GetSizeBytes())
 	}
 }
 
@@ -257,6 +259,8 @@ func uploadBzAction(casAddr, commandDigestStr, rootDigestStr string, noCache, ac
 			log.Fatalf("Error converting digest to JSON: %v", err)
 		}
 		fmt.Printf("%s\n", b)
+	} else {
+		fmt.Printf("%s/%d\n", digest.GetHash(), digest.GetSizeBytes())
 	}
 }
 
@@ -279,6 +283,8 @@ func execute(execAddr, actionDigestStr string, skipCache bool, execJson bool) {
 			log.Fatalf("Error converting operation to JSON: %v", err)
 		}
 		fmt.Printf("%s\n", b)
+	} else {
+		fmt.Printf("%s\n", operation.GetName())
 	}
 }
 
@@ -296,6 +302,8 @@ func getOperation(execAddr, opName string, getJson bool) {
 			log.Fatalf("Error converting operation to JSON: %v", err)
 		}
 		fmt.Printf("%s\n", b)
+	} else {
+		fmt.Printf("%s\n", operation.GetName())
 	}
 }
 

--- a/common/log/helpers/helpers.go
+++ b/common/log/helpers/helpers.go
@@ -31,7 +31,7 @@ func LogRunStatus(status *scoot.JobStatus) {
 	log.Info("Task Data:")
 	for task, runStatus := range status.GetTaskData() {
 		if runStatus == nil {
-			log.Infof("%s: ExitCode: <nil>, Error: <nil>")
+			log.Infof("%s: ExitCode: <nil>, Error: <nil>", task)
 			continue
 		}
 		log.Infof("%s: ExitCode: %v, Error: %v", task, runStatus.GetExitCode(), runStatus.GetError())

--- a/sched/definitions_property_test.go
+++ b/sched/definitions_property_test.go
@@ -21,13 +21,13 @@ func Test_JobSerializeDeserialize(t *testing.T) {
 
 			binaryJob, err := job.Serialize()
 			if err != nil {
-				log.Info("Unexpected Error Occurred when Serializing Job %v", err)
+				log.Infof("Unexpected Error Occurred when Serializing Job %v", err)
 				return false
 			}
 
 			deserializedJob, err := DeserializeJob(binaryJob)
 			if err != nil {
-				log.Info("Unexpected Error Occurred when Deserializing Job %v", err)
+				log.Infof("Unexpected Error Occurred when Deserializing Job %v", err)
 				return false
 			}
 			return reflect.DeepEqual(job, deserializedJob)

--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -440,8 +440,10 @@ func (s *statefulScheduler) loop() {
 	for {
 		s.step()
 
-		// wait until our TickRate has elapsed or we have a pending action.
-		// resend messages asynchronously in case the channel is blocked.
+		// Wait until our TickRate has elapsed or we have a pending action.
+		// Detect pending action by monitoring statefulScheduler's job channels.
+		// Since "detect" means we pulled off of a channel, put it back,
+		// asynchronously in case the channel is blocked/full (it will be drained next step())
 		select {
 		case msg := <-s.checkJobCh:
 			go func() {

--- a/snapshot/store/http_store.go
+++ b/snapshot/store/http_store.go
@@ -97,7 +97,7 @@ func (s *httpStore) Exists(name string) (bool, error) {
 		log.Infof("Exists error: %s %v", name, err)
 		return false, err
 	}
-	log.Infof("Exists ok: %s %v", name)
+	log.Infof("Exists ok: %s", name)
 	r.Close()
 	return true, nil
 }
@@ -131,7 +131,7 @@ func (s *httpStore) Write(name string, data io.Reader, ttl *TTLValue) error {
 	} else {
 		resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			log.Infof("Write response status error: %s %v -- %s", uri, resp.Status)
+			log.Infof("Write response status error: %s -- %s", uri, resp.Status)
 			return errors.New(resp.Status)
 		}
 	}


### PR DESCRIPTION
Circled back to this after doing a little scheduler queue latency profiling on my flight.

Most of our scheduler queue latency stemmed from the scheduler TickRate. With this change we don't sleep the full tick if there's pending work on the scheduler's channels. Gets us about a 10x reduction in queue latency, at least from a local cluster perspective.

Also updated bzutil to print digests to stdout by default, and fixed some hidden go fmt/vet errors.