### PR TITLE
bazel/server - add grpc max connection idle time

### DIFF
--- a/bazel/constants.go
+++ b/bazel/constants.go
@@ -14,4 +14,11 @@ const (
 	// Nil-data/Empty SHA-256 data
 	EmptySha  = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 	EmptySize = int64(0)
+
+	// GRPC Server connection-related setting limits (defaults)
+	MaxSimultaneousConnections = 0 // limits total simultaneous connections via the Listener
+	MaxRequestsPerSecond       = 0 // limits total incoming requests allowed per second
+	MaxRequestsBurst           = 0 // allows this many requests in a burst faster than MaxRPS average
+	MaxConcurrentStreams       = 0 // limits concurrent streams _per client_
+	MaxConnIdleMins            = 1 // limits open idle connections before the server closes them
 )

--- a/bazel/execution/client.go
+++ b/bazel/execution/client.go
@@ -61,6 +61,7 @@ func Execute(r dialer.Resolver, actionDigest *remoteexecution.Digest, skipCache 
 	if err != nil {
 		return nil, fmt.Errorf("Failed to dial server %s: %s", serverAddr, err)
 	}
+	defer cc.Close()
 
 	req := &remoteexecution.ExecuteRequest{
 		ActionDigest:    actionDigest,
@@ -77,13 +78,13 @@ func execFromClient(ec remoteexecution.ExecutionClient, req *remoteexecution.Exe
 	if err != nil {
 		return nil, err
 	}
+	defer execClient.CloseSend()
 
 	op, err := execClient.Recv()
 	if err != nil {
 		return nil, err
 	}
 
-	execClient.CloseSend()
 	return op, nil
 }
 

--- a/binaries/apiserver/main.go
+++ b/binaries/apiserver/main.go
@@ -36,6 +36,7 @@ func main() {
 	grpcRate := flag.Int("max_grpc_rps", cas.MaxRequestsPerSecond, "max grpc incoming requests per second")
 	grpcBurst := flag.Int("max_grpc_rps_burst", cas.MaxRequestsBurst, "max grpc incoming requests burst")
 	grpcStreams := flag.Int("max_grpc_streams", cas.MaxConcurrentStreams, "max grpc streams per client")
+	grpcIdleMins := flag.Int("max_grpc_idle_mins", bazel.MaxConnIdleMins, "max grpc connection idle time")
 	flag.Parse()
 
 	level, err := log.ParseLevel(*logLevelFlag)
@@ -104,6 +105,7 @@ func main() {
 				RateLimitPerSec:   *grpcRate,
 				BurstLimitPerSec:  *grpcBurst,
 				ConcurrentStreams: *grpcStreams,
+				MaxConnIdleMins:   *grpcIdleMins,
 			}
 		},
 	)

--- a/binaries/scheduler/main.go
+++ b/binaries/scheduler/main.go
@@ -30,10 +30,11 @@ func main() {
 	grpcAddr := flag.String("grpc_addr", scootapi.DefaultSched_GRPC, "Bind address for grpc server")
 	configFlag := flag.String("config", "local.memory", "Scheduler Config (either a filename like local.memory or JSON text")
 	logLevelFlag := flag.String("log_level", "info", "Log everything at this level and above (error|info|debug)")
-	grpcConns := flag.Int("max_grpc_conn", 0, "max grpc listener connections")
-	grpcRate := flag.Int("max_grpc_rps", 0, "max grpc incoming requests per second")
-	grpcBurst := flag.Int("max_grpc_rps_burst", 0, "max grpc incoming requests burst")
-	grpcStreams := flag.Int("max_grpc_streams", 0, "max grpc streams per client")
+	grpcConns := flag.Int("max_grpc_conn", bazel.MaxSimultaneousConnections, "max grpc listener connections")
+	grpcRate := flag.Int("max_grpc_rps", bazel.MaxRequestsPerSecond, "max grpc incoming requests per second")
+	grpcBurst := flag.Int("max_grpc_rps_burst", bazel.MaxRequestsBurst, "max grpc incoming requests burst")
+	grpcStreams := flag.Int("max_grpc_streams", bazel.MaxConcurrentStreams, "max grpc streams per client")
+	grpcIdleMins := flag.Int("max_grpc_idle_mins", bazel.MaxConnIdleMins, "max grpc connection idle time")
 	flag.Parse()
 
 	level, err := log.ParseLevel(*logLevelFlag)
@@ -68,6 +69,7 @@ func main() {
 				RateLimitPerSec:   *grpcRate,
 				BurstLimitPerSec:  *grpcBurst,
 				ConcurrentStreams: *grpcStreams,
+				MaxConnIdleMins:   *grpcIdleMins,
 			}
 		},
 


### PR DESCRIPTION
Don't let clients potentially use up finite connections when idle. To be combined internally with 
"export GRPC_GO_LOG_VERBOSITY_LEVEL=99 && export GRPC_GO_LOG_SEVERITY_LEVEL=info" for debugging.