### PR TITLE
Abort tasks with SIGTERM to allow for cleanup

### DIFF
--- a/runner/execer/os/easy_test.go
+++ b/runner/execer/os/easy_test.go
@@ -153,7 +153,8 @@ func TestMemCap(t *testing.T) {
 	select {
 	case <-memCh:
 		if usage, err = e.memUsage(pid); err != nil {
-			t.Fatalf(err.Error())
+			// We don't return this error because it just means the process was already killed
+			log.Error("Error finding memUsage: %s", err)
 		}
 		if usage != 0 {
 			t.Fatalf("Expected usage to be 0MB, was: %dB", usage)

--- a/runner/execer/os/easy_test.go
+++ b/runner/execer/os/easy_test.go
@@ -154,7 +154,7 @@ func TestMemCap(t *testing.T) {
 	case <-memCh:
 		if usage, err = e.memUsage(pid); err != nil {
 			// We don't return this error because it just means the process was already killed
-			log.Error("Error finding memUsage: %s", err)
+			log.Errorf("Error finding memUsage: %s", err)
 		}
 		if usage != 0 {
 			t.Fatalf("Expected usage to be 0MB, was: %dB", usage)

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -412,15 +412,15 @@ func (p *osProcess) Abort() (result execer.ProcessStatus) {
 	doneCh := make(chan error)
 	var err error
 	go func() {
-		doneCh <- p.cmd.Process.Signal(os.Interrupt)
+		doneCh <- p.cmd.Process.Signal(syscall.SIGTERM)
 	}()
 	select {
 	case err = <-doneCh:
 		if err != nil {
-			log.Errorf("Error aborting command via SIGINT: %s", err)
+			log.Errorf("Error aborting command via SIGTERM: %s", err)
 			err = p.Kill()
 		} else {
-			log.Info("Process aborted via SIGINT")
+			log.Info("Process aborted via SIGTERM")
 		}
 	case <-time.After(10 * time.Second):
 		msg := "10 second timeout for graceful abort exceeded."
@@ -429,7 +429,7 @@ func (p *osProcess) Abort() (result execer.ProcessStatus) {
 		err = p.Kill()
 	}
 	if err != nil {
-		result.Error += "Couldn't kill process. Will still attempt cleanup."
+		result.Error += " Couldn't kill process. Will still attempt cleanup."
 	}
 	_, err = p.cmd.Process.Wait()
 	if err, ok := err.(*exec.ExitError); ok {

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -22,14 +22,19 @@ import (
 
 const bytesToKB = 1024
 
-func NewExecer() *osExecer {
-	return &osExecer{pg: &osProcGetter{}}
+// Used for mocking memCap monitoring
+type procGetter interface {
+	getProcs() (map[int]proc, map[int][]proc, map[int][]proc, error)
+	parseProcs([]string) (map[int]proc, map[int][]proc, map[int][]proc, error)
 }
 
-// For now memory can be capped on a per-execer basis rather than a per-command basis.
-// This is ok since we currently (Q1 2017) only support one run at a time in our codebase.
-func NewBoundedExecer(memCap execer.Memory, stat stats.StatsReceiver) *osExecer {
-	return &osExecer{memCap: memCap, stat: stat.Scope("osexecer"), pg: &osProcGetter{}}
+type WriterDelegater interface {
+	// Return an underlying Writer. Why? Because some methods type assert to
+	// a more specific type and are more clever (e.g., if it's an *os.File, hook it up
+	// directly to a new process's stdout/stderr.)
+	// We care about this cleverness, so Output both is-a and has-a Writer
+	// Cf. runner/runners/local_output.go
+	WriterDelegate() io.Writer
 }
 
 type osExecer struct {
@@ -56,21 +61,16 @@ type proc struct {
 	rss  int
 }
 
-type procGetter interface {
-	getProcs() (map[int]proc, map[int][]proc, map[int][]proc, error)
-	parseProcs([]string) (map[int]proc, map[int][]proc, map[int][]proc, error)
+func NewExecer() *osExecer {
+	return &osExecer{pg: &osProcGetter{}}
 }
 
-type WriterDelegater interface {
-	// Return an underlying Writer. Why? Because some methods type assert to
-	// a more specific type and are more clever (e.g., if it's an *os.File, hook it up
-	// directly to a new process's stdout/stderr.)
-	// We care about this cleverness, so Output both is-a and has-a Writer
-	// Cf. runner/runners/local_output.go
-	WriterDelegate() io.Writer
+func NewBoundedExecer(memCap execer.Memory, stat stats.StatsReceiver) *osExecer {
+	return &osExecer{memCap: memCap, stat: stat.Scope("osexecer"), pg: &osProcGetter{}}
 }
 
-func (e *osExecer) Exec(command execer.Command) (result execer.Process, err error) {
+// Start a command, monitor its memory, and return an &osProcess wrapper for it
+func (e *osExecer) Exec(command execer.Command) (execer.Process, error) {
 	if len(command.Argv) == 0 {
 		return nil, errors.New("No command specified.")
 	}
@@ -131,10 +131,6 @@ func (e *osExecer) Exec(command execer.Command) (result execer.Process, err erro
 	return proc, nil
 }
 
-// TODO(rcouto): More we can do here to make sure we're
-// cleaning up after ourselves completely / not leaving
-// orphaned processes behind
-//
 // Periodically check to make sure memory constraints are respected,
 // and clean up after ourselves when the process has completed
 func (e *osExecer) monitorMem(p *osProcess, memCh chan execer.ProcessStatus) {
@@ -289,6 +285,7 @@ func (e *osExecer) memUsage(pid int) (execer.Memory, error) {
 	return execer.Memory(total * bytesToKB), nil
 }
 
+// Get a full list of processes running, including their pid, pgid, ppid, and memory usage
 func (pg *osProcGetter) getProcs() (
 	allProcesses map[int]proc, processGroups map[int][]proc,
 	parentProcesses map[int][]proc, err error) {
@@ -302,6 +299,7 @@ func (pg *osProcGetter) getProcs() (
 	return pg.parseProcs(procs)
 }
 
+// Format processes into pgid and ppid groups for summation of memory usage
 func (pg *osProcGetter) parseProcs(procs []string) (allProcesses map[int]proc, processGroups map[int][]proc,
 	parentProcesses map[int][]proc, err error) {
 	allProcesses = make(map[int]proc)
@@ -323,16 +321,11 @@ func (pg *osProcGetter) parseProcs(procs []string) (allProcesses map[int]proc, p
 	return allProcesses, processGroups, parentProcesses, nil
 }
 
-/*
-Wait for the process to finish.
-
-If the command finishes without error return the status COMPLETE and exit Code 0.
-
-If the command fails, and we can get the exit code from the command, return COMPLETE with the failing exit code.
-
-if the command fails and we cannot get the exit code from the command, return FAILED and the error
-that prevented getting the exit code.
-*/
+// Wait for the process to finish.
+// If the command finishes without error return the status COMPLETE and exit Code 0.
+// If the command fails, and we can get the exit code from the command, return COMPLETE with the failing exit code.
+// if the command fails and we cannot get the exit code from the command, return FAILED and the error
+// that prevented getting the exit code.
 func (p *osProcess) Wait() (result execer.ProcessStatus) {
 	// Wait for the output goroutines to finish then wait on the process itself to release resources.
 	p.wg.Wait()
@@ -395,6 +388,8 @@ func (p *osProcess) Wait() (result execer.ProcessStatus) {
 	return result
 }
 
+// Attempt to SIGTERM process, allowing for graceful exit
+// SIGKILL after 10 seconds or if osProcess.cmd.Wait() returns an error
 func (p *osProcess) Abort() execer.ProcessStatus {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
@@ -407,33 +402,90 @@ func (p *osProcess) Abort() execer.ProcessStatus {
 	p.result.ExitCode = -1
 	p.result.Error = "Aborted."
 
-	// Attempt to SIGTERM process, allowing for graceful exit
-	// SIGKILL after 10 seconds
-	doneCh := make(chan error)
+	sigCh := make(chan error)
 	var err error
+
 	go func() {
-		doneCh <- p.cmd.Process.Signal(syscall.SIGTERM)
+		sigCh <- p.cmd.Process.Signal(syscall.SIGTERM)
 	}()
+
 	select {
-	case err = <-doneCh:
+	case err = <-sigCh:
 		if err != nil {
-			log.Errorf("Error aborting command via SIGTERM: %s", err)
-			err = p.Kill()
+			msg := fmt.Sprintf("Error aborting command via SIGTERM: %s.", err)
+			log.WithFields(
+				log.Fields{
+					"pid":    p.cmd.Process.Pid,
+					"tag":    p.Tag,
+					"jobID":  p.JobID,
+					"taskID": p.TaskID,
+				}).Errorf(msg)
+			p.KillAndWait(msg)
 		} else {
-			log.Info("Process aborted via SIGTERM")
+			log.WithFields(
+				log.Fields{
+					"pid":    p.cmd.Process.Pid,
+					"tag":    p.Tag,
+					"jobID":  p.JobID,
+					"taskID": p.TaskID,
+				}).Info("Aborting process via SIGTERM")
 		}
-	case <-time.After(10 * time.Second):
-		msg := "10 second timeout for graceful abort exceeded."
-		log.Error(msg)
-		p.KillAndWait(fmt.Sprintf("%s. Killing command.", msg))
 	}
-	return *p.result
+
+	// Add buffer in case of race condition where both <-cmdDoneCh returns an error & timeout is exceeded at same time
+	errCh := make(chan error, 1)
+	go func() {
+		select {
+		case <-time.After(time.Second * 10):
+			errCh <- errors.New("10 second timeout exceeded.")
+		}
+	}()
+
+	cmdDoneCh := make(chan error)
+	go func() {
+		cmdDoneCh <- p.cmd.Wait()
+	}()
+
+	for {
+		select {
+		case err = <-cmdDoneCh:
+			if err != nil {
+				msg := fmt.Sprintf("Command failed to finish: %v", err)
+				log.WithFields(
+					log.Fields{
+						"pid":    p.cmd.Process.Pid,
+						"tag":    p.Tag,
+						"jobID":  p.JobID,
+						"taskID": p.TaskID,
+					}).Error(msg)
+				errCh <- errors.New(msg)
+				// Loop back and pull from cmdFailCh to force cleanup
+			} else {
+				log.WithFields(
+					log.Fields{
+						"pid":    p.cmd.Process.Pid,
+						"tag":    p.Tag,
+						"jobID":  p.JobID,
+						"taskID": p.TaskID,
+					}).Info("Command finished via SIGTERM")
+				return *p.result
+			}
+		case msg := <-errCh:
+			log.WithFields(
+				log.Fields{
+					"pid":    p.cmd.Process.Pid,
+					"tag":    p.Tag,
+					"jobID":  p.JobID,
+					"taskID": p.TaskID,
+				}).Error(msg)
+			p.KillAndWait(fmt.Sprintf("%s. Killing command.", msg))
+			return *p.result
+		default:
+		}
+	}
 }
 
-func (p *osProcess) Kill() error {
-	return p.cmd.Process.Kill()
-}
-
+// Kill osProcess for exceeding MemCap
 func (p *osProcess) MemCapKill() {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
@@ -445,9 +497,23 @@ func (p *osProcess) MemCapKill() {
 	p.KillAndWait("Killed for memory usage over MemCap")
 }
 
+// Kills osProcess via SIGKILL and all processes of its pgid
 func (p *osProcess) KillAndWait(resultError string) {
+	pgid, err := syscall.Getpgid(p.cmd.Process.Pid)
+	if err != nil {
+		log.WithFields(
+			log.Fields{
+				"pid":    p.cmd.Process.Pid,
+				"error":  err,
+				"tag":    p.Tag,
+				"jobID":  p.JobID,
+				"taskID": p.TaskID,
+			}).Error("Error finding pgid")
+	} else {
+		defer cleanupProcs(pgid)
+	}
 	p.result.Error += fmt.Sprintf(" %s", resultError)
-	err := p.Kill()
+	err = p.cmd.Process.Kill()
 	if err != nil {
 		p.result.Error += fmt.Sprintf(" Couldn't kill process: %s. Will still attempt cleanup.", err)
 	}

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -407,7 +407,7 @@ func (p *osProcess) Abort() (result execer.ProcessStatus) {
 	result.ExitCode = -1
 	result.Error = "Aborted."
 
-	// Attempt to SIGINT process, allowing for graceful exit
+	// Attempt to SIGTERM process, allowing for graceful exit
 	// SIGKILL after 10 seconds
 	doneCh := make(chan error)
 	var err error

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -425,7 +425,7 @@ func (p *osProcess) Abort() execer.ProcessStatus {
 	case <-time.After(10 * time.Second):
 		msg := "10 second timeout for graceful abort exceeded."
 		log.Error(msg)
-		p.KillAndWait(fmt.Sprintf(" %s. Killing command.", msg))
+		p.KillAndWait(fmt.Sprintf("%s. Killing command.", msg))
 	}
 	return *p.result
 }
@@ -442,11 +442,11 @@ func (p *osProcess) MemCapKill() {
 	}
 	p.result.State = execer.FAILED
 	p.result.ExitCode = -1
-	p.result.Error = resultError
 	p.KillAndWait("Killed for memory usage over MemCap")
 }
 
 func (p *osProcess) KillAndWait(resultError string) {
+	p.result.Error += fmt.Sprintf(" %s", resultError)
 	err := p.Kill()
 	if err != nil {
 		p.result.Error += fmt.Sprintf(" Couldn't kill process: %s. Will still attempt cleanup.", err)

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -449,7 +449,7 @@ func (p *osProcess) Abort() execer.ProcessStatus {
 						"taskID": p.TaskID,
 					}).Error(msg)
 				errCh <- errors.New(msg)
-				// Loop back and pull from cmdFailCh to force cleanup
+				// Loop back and pull from errCh to force cleanup
 			} else {
 				log.WithFields(
 					log.Fields{

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -395,7 +395,7 @@ func (p *osProcess) Wait() (result execer.ProcessStatus) {
 	return result
 }
 
-func (p *osProcess) Abort() (result *execer.ProcessStatus) {
+func (p *osProcess) Abort() (result execer.ProcessStatus) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 	if p.result != nil {

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -440,14 +440,13 @@ func (p *osProcess) MemCapKill() {
 	if p.result == nil {
 		p.result = &execer.ProcessStatus{}
 	}
+	p.result.State = execer.FAILED
+	p.result.ExitCode = -1
+	p.result.Error = resultError
 	p.KillAndWait("Killed for memory usage over MemCap")
 }
 
 func (p *osProcess) KillAndWait(resultError string) {
-	p.result = &execer.ProcessStatus{}
-	p.result.State = execer.FAILED
-	p.result.ExitCode = -1
-	p.result.Error = resultError
 	err := p.Kill()
 	if err != nil {
 		p.result.Error += fmt.Sprintf(" Couldn't kill process: %s. Will still attempt cleanup.", err)

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -252,8 +252,7 @@ func (e *osExecer) memUsage(pid int) (execer.Memory, error) {
 		return 0, nil
 	}
 	if _, ok := allProcesses[pid]; !ok {
-		log.Errorf("%d was not present in list of all processes", pid)
-		return 0, nil
+		return 0, fmt.Errorf("%d was not present in list of all processes", pid)
 	}
 	procGroupID := allProcesses[pid].pgid
 	// We have relatedProcesses & relatedProcessesMap b/c iterating over the range of a map while modifying it in place

--- a/runner/execer/os/os_execer_test.go
+++ b/runner/execer/os/os_execer_test.go
@@ -96,17 +96,29 @@ func TestAbortCatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	pid := proc.(*osProcess).cmd.Process.Pid
+
 	time.Sleep(2 * time.Second)
-	usage, err := e.memUsage(proc.(*osProcess).cmd.Process.Pid)
+	usage, err := e.memUsage(pid)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if usage == 0 {
-		t.Fatalf("Expected usage to be >0 for process %d", proc.(*osProcess).cmd.Process.Pid)
+		t.Fatalf("Expected usage to be >0 for process %d", pid)
 	}
+
 	proc.Abort()
-	usage, err = e.memUsage(proc.(*osProcess).cmd.Process.Pid)
-	if usage != 0 && err == nil {
+	usage, err = e.memUsage(pid)
+	if usage != 0 {
+		t.Fatalf("Expected memUsage to be 0 after Abort & Kill, was %d", usage)
+	}
+
+	time.Sleep(3 * time.Second)
+	usage, err = e.memUsage(pid)
+	if err == nil {
+		t.Fatalf("Expected %d to not exist as a process anymore.", pid)
+	}
+	if usage != 0 {
 		t.Fatalf("Expected memUsage to be 0 after Abort & Kill, was %d", usage)
 	}
 }

--- a/runner/execer/os/trap_script.sh
+++ b/runner/execer/os/trap_script.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+trap ':' SIGTERM
+
+while :
+do
+	python -c `import time; exec("x=[]\nfor i in range(50):\n x.append(' ' * 1024*1024)\n time.sleep(.1)")`
+done

--- a/runner/execer/os/trap_script.sh
+++ b/runner/execer/os/trap_script.sh
@@ -3,5 +3,5 @@ trap ':' SIGTERM
 
 while :
 do
-	python -c `import time; exec("x=[]\nfor i in range(50):\n x.append(' ' * 1024*1024)\n time.sleep(.1)")`
+	python -c 'import time; exec("x=[]\nfor i in range(1):\n x.append(\" \" * 1024*1024)\n time.sleep(.1)")'
 done


### PR DESCRIPTION
Problem

When we abort a task, we send it a SIGKILL and don't give it a chance to cleanup after itself

Solution

Pass a SIGTERM for aborted tasks, with a 10 second timeout leading to a SIGKILL. For tasks that exceed memCap, we still SIGKILL.

Result

Tasks will be allowed to cleanup after themselves.
