### PR TITLE
Dgassaway/dpt 15508/grpc limits

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,7 +37,7 @@
 [submodule "vendor/golang.org/x/sys"]
 	path = vendor/golang.org/x/sys
 	url = https://go.googlesource.com/sys
-	branch = 62bee037599929a6e9146f29d10dd5208c43507d
+	branch = fc99dfbffb4e5ed5758a37e31dd861afe285406b
 [submodule "vendor/github.com/luci/go-render"]
 	path = vendor/github.com/luci/go-render
 	url = https://github.com/luci/go-render

--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 [submodule "vendor/google.golang.org/grpc"]
 	path = vendor/google.golang.org/grpc
 	url = https://github.com/grpc/grpc-go
-	branch = 7a6a684ca69eb4cae85ad0a484f2e531598c047b
+	branch = 045159ad57f3781d409358e3ade910a018c16b30
 [submodule "vendor/github.com/golang/protobuf"]
 	path = vendor/github.com/golang/protobuf
 	url = https://github.com/golang/protobuf

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SCOOT_LOGLEVEL ?= info
 TRAVIS_FILTER ?= 2>&1 | tee /dev/null | egrep -v 'line="(runners|scheduler/task_|gitdb)'
 
 default:
-	go build $$(go list ./... | grep -v vendor)
+	go build $$(go list ./... | grep -v /vendor/)
 
 dependencies:
 	# Populates the vendor directory to reflect the latest run of check-dependencies.
@@ -42,33 +42,33 @@ check-dependencies:
 	go get github.com/golang/mock/mockgen
 
 generate:
-	go generate $$(go list ./... | grep -v vendor)
+	go generate $$(go list ./... | grep -v /vendor/)
 
 format:
-	go fmt $$(go list ./... | grep -v vendor)
+	go fmt $$(go list ./... | grep -v /vendor/)
 
 fs_util:
 	# Fetches fs_util tool from pantsbuild binaries
 	sh get_fs_util.sh
 
 vet:
-	go vet $$(go list ./... | grep -v vendor)
+	go vet $$(go list ./... | grep -v /vendor/)
 
 coverage:
 	sh testCoverage.sh $(TRAVIS_FILTER)
 
 test-unit-property-integration: fs_util
 	# Runs all tests including integration and property tests
-	go test -count=1 -race -timeout 120s -tags="integration property_test" $$(go list ./... | grep -v vendor | grep -v /cmd/) $(TRAVIS_FILTER)
+	go test -count=1 -race -timeout 120s -tags="integration property_test" $$(go list ./... | grep -v /vendor/ | grep -v /cmd/) $(TRAVIS_FILTER)
 
 test-unit-property:
 	# Runs only unit tests and property tests
-	go test -count=1 -race -timeout 120s -tags="property_test" $$(go list ./... | grep -v vendor | grep -v /cmd/) $(TRAVIS_FILTER)
+	go test -count=1 -race -timeout 120s -tags="property_test" $$(go list ./... | grep -v /vendor/ | grep -v /cmd/) $(TRAVIS_FILTER)
 
 test-unit:
 	# Runs only unit tests
 	# Only invoked manually so we don't need to modify output
-	go test -count=1 -race -timeout 120s $$(go list ./... | grep -v vendor | grep -v /cmd/)
+	go test -count=1 -race -timeout 120s $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)
 
 testlocal: generate test
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SCOOT_LOGLEVEL ?= info
 TRAVIS_FILTER ?= 2>&1 | tee /dev/null | egrep -v 'line="(runners|scheduler/task_|gitdb)'
 
 default:
-	go build $$(go list ./... | grep -v /vendor/)
+	go build $$(go list ./... | grep -v vendor)
 
 dependencies:
 	# Populates the vendor directory to reflect the latest run of check-dependencies.
@@ -42,33 +42,33 @@ check-dependencies:
 	go get github.com/golang/mock/mockgen
 
 generate:
-	go generate $$(go list ./... | grep -v /vendor/)
+	go generate $$(go list ./... | grep -v vendor)
 
 format:
-	go fmt $$(go list ./... | grep -v /vendor/)
+	go fmt $$(go list ./... | grep -v vendor)
 
 fs_util:
 	# Fetches fs_util tool from pantsbuild binaries
 	sh get_fs_util.sh
 
 vet:
-	go vet $$(go list ./... | grep -v /vendor/)
+	go vet $$(go list ./... | grep -v vendor)
 
 coverage:
 	sh testCoverage.sh $(TRAVIS_FILTER)
 
 test-unit-property-integration: fs_util
 	# Runs all tests including integration and property tests
-	go test -count=1 -race -timeout 120s -tags="integration property_test" $$(go list ./... | grep -v /vendor/ | grep -v /cmd/) $(TRAVIS_FILTER)
+	go test -count=1 -race -timeout 120s -tags="integration property_test" $$(go list ./... | grep -v vendor | grep -v /cmd/) $(TRAVIS_FILTER)
 
 test-unit-property:
 	# Runs only unit tests and property tests
-	go test -count=1 -race -timeout 120s -tags="property_test" $$(go list ./... | grep -v /vendor/ | grep -v /cmd/) $(TRAVIS_FILTER)
+	go test -count=1 -race -timeout 120s -tags="property_test" $$(go list ./... | grep -v vendor | grep -v /cmd/) $(TRAVIS_FILTER)
 
 test-unit:
 	# Runs only unit tests
 	# Only invoked manually so we don't need to modify output
-	go test -count=1 -race -timeout 120s $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)
+	go test -count=1 -race -timeout 120s $$(go list ./... | grep -v vendor | grep -v /cmd/)
 
 testlocal: generate test
 

--- a/bazel/cas/constants.go
+++ b/bazel/cas/constants.go
@@ -22,10 +22,10 @@ const (
 	ResultAddressKey = "ActionCacheResult"
 
 	// GRPC Server connection-related setting limits recommended for CAS
-	MaxSimultaneousConnections = 200 // limits total simultaneous connections via the Listener
-	MaxRequestsPerSecond       = 100 // limits total incoming requests allowed per second
-	MaxRequestsBurst           = 20  // allows this many requests in a burst faster than MaxRPS average
-	MaxConcurrentStreams       = 10  // limits concurrent streams _per client_
+	MaxSimultaneousConnections = 1000 // limits total simultaneous connections via the Listener
+	MaxRequestsPerSecond       = 500  // limits total incoming requests allowed per second
+	MaxRequestsBurst           = 250  // allows this many requests in a burst faster than MaxRPS average
+	MaxConcurrentStreams       = 0    // limits concurrent streams _per client_
 )
 
 // Resource naming format guidelines

--- a/common/dialer/resolver.go
+++ b/common/dialer/resolver.go
@@ -10,9 +10,10 @@ type Resolver interface {
 	// Resolve resolves a service, getting an address or URL
 	// If a Resolve() call completes successfully but finds no addresses, it will return ("", nil)
 	Resolve() (string, error)
-	// ResolveAll resolves a slice of all known addresses or URLs
-	// If a ResolveAll() call completes successfully but finds no addresses, it will return ([]string{}, nil)
-	ResolveAll() ([]string, error)
+	// ResolveMany resolves a slice of random addresses or URLs
+	// The int parameter specifies the maximum number of addresses to return. If 0, all addresses are returned.
+	// If the call completes successfully but finds no addresses, it will return ([]string{}, nil)
+	ResolveMany(int) ([]string, error)
 }
 
 // ConstantResolver always returns the same value
@@ -30,8 +31,8 @@ func (r *ConstantResolver) Resolve() (string, error) {
 	return r.s, nil
 }
 
-// ResolveAll returns the constant in a slice
-func (r *ConstantResolver) ResolveAll() ([]string, error) {
+// ResolveMany returns the constant in a slice
+func (r *ConstantResolver) ResolveMany(n int) ([]string, error) {
 	all := []string{}
 	if r.s != "" {
 		all = append(all, r.s)
@@ -54,8 +55,8 @@ func (r *EnvResolver) Resolve() (string, error) {
 	return os.Getenv(r.key), nil
 }
 
-// ResolveAll retuns the env key in a slice
-func (r *EnvResolver) ResolveAll() ([]string, error) {
+// ResolveMany retuns the env key in a slice
+func (r *EnvResolver) ResolveMany(n int) ([]string, error) {
 	all := []string{}
 	s, err := r.Resolve()
 	if s != "" {
@@ -86,10 +87,10 @@ func (r *CompositeResolver) Resolve() (string, error) {
 	return "", fmt.Errorf("could not resolve: no delegate resolved: %v", r.dels)
 }
 
-// ResolveAll resolves by resolving, in order, via delegates
-func (r *CompositeResolver) ResolveAll() ([]string, error) {
+// ResolveMany resolves by resolving, in order, via delegates
+func (r *CompositeResolver) ResolveMany(n int) ([]string, error) {
 	for _, r := range r.dels {
-		if s, err := r.ResolveAll(); len(s) != 0 || err != nil {
+		if s, err := r.ResolveMany(n); len(s) != 0 || err != nil {
 			return s, err
 		}
 	}

--- a/common/dialer/resolver.go
+++ b/common/dialer/resolver.go
@@ -11,7 +11,7 @@ type Resolver interface {
 	// If a Resolve() call completes successfully but finds no addresses, it will return ("", nil)
 	Resolve() (string, error)
 	// ResolveMany resolves a slice of random addresses or URLs
-	// The int parameter specifies the maximum number of addresses to return. If 0, all addresses are returned.
+	// The int parameter specifies the maximum number of addresses to return. If <= 0, all addresses are returned.
 	// If the call completes successfully but finds no addresses, it will return ([]string{}, nil)
 	ResolveMany(int) ([]string, error)
 }

--- a/common/dialer/resolver_test.go
+++ b/common/dialer/resolver_test.go
@@ -17,7 +17,7 @@ func TestConstantResolver(t *testing.T) {
 		t.Fatalf("got: %s, want: %s", res, addr)
 	}
 
-	slice, err := c.ResolveAll()
+	slice, err := c.ResolveMany(0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestEnvResolver(t *testing.T) {
 		t.Fatalf("got: %s, want: %s", res, addr)
 	}
 
-	slice, err := e.ResolveAll()
+	slice, err := e.ResolveMany(0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestCompositeResolver(t *testing.T) {
 
 	os.Setenv("SCOOT_TEST_ADDR", addr2)
 
-	slice, err := e.ResolveAll()
+	slice, err := e.ResolveMany(0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scootapi/locate.go
+++ b/scootapi/locate.go
@@ -67,7 +67,7 @@ func (r *BundlestoreResolver) Resolve() (string, error) {
 	return APIAddrToBundlestoreURI(s), nil
 }
 
-func (r *BundlestoreResolver) ResolveAll() ([]string, error) {
+func (r *BundlestoreResolver) ResolveMany(n int) ([]string, error) {
 	_, s, err := GetScootapiAddr()
 	if s == "" || err != nil {
 		return []string{}, err

--- a/snapshot/bazel/bz_tree.go
+++ b/snapshot/bazel/bz_tree.go
@@ -102,7 +102,7 @@ func (bc bzCommand) materialize(sha string, size int64, dir string) error {
 
 // Runs fsUtilCmd as an os/exec.Cmd with appropriate flags
 func (bc bzCommand) runCmd(args []string) ([]byte, []byte, error) {
-	serverAddrs, err := bc.casResolver.ResolveAll()
+	serverAddrs, err := bc.casResolver.ResolveMany(maxResolveToFSUtil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/snapshot/bazel/constants.go
+++ b/snapshot/bazel/constants.go
@@ -22,4 +22,6 @@ const (
 	fsUtilCmdGlobWildCard = "**"
 
 	emptyID = bazel.SnapshotIDPrefix + "-" + bazel.EmptySha + "-0"
+
+	maxResolveToFSUtil = 10
 )

--- a/snapshot/bazel/constants.go
+++ b/snapshot/bazel/constants.go
@@ -23,5 +23,7 @@ const (
 
 	emptyID = bazel.SnapshotIDPrefix + "-" + bazel.EmptySha + "-0"
 
+	// limit amount of CAS addresses resolved in BzFiler calls to fs_util to this
+	// value, in order to limit number of connections
 	maxResolveToFSUtil = 5
 )

--- a/snapshot/bazel/constants.go
+++ b/snapshot/bazel/constants.go
@@ -23,5 +23,5 @@ const (
 
 	emptyID = bazel.SnapshotIDPrefix + "-" + bazel.EmptySha + "-0"
 
-	maxResolveToFSUtil = 10
+	maxResolveToFSUtil = 5
 )


### PR DESCRIPTION
* Bump grpc connection limits on CAS server by ~5x, and remove stream limit (probably doens't matter)
* Changed Resolver interface's ResolveAll -> ResolveMany, which supports capping the number of returned addresses (passing 0 behaves like ResolveAll).
* Cap number of resolved addresses passed to fs_util calls at 10 to try and cap total connections