### PR TITLE
Implement CancelOperation

### DIFF
--- a/bazel/execution/client.go
+++ b/bazel/execution/client.go
@@ -1,16 +1,20 @@
 package execution
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	remoteexecution "github.com/twitter/scoot/bazel/remoteexecution"
+	"github.com/twitter/scoot/bazel/remoteexecution"
 	"golang.org/x/net/context"
 	"google.golang.org/genproto/googleapis/longrunning"
-	google_rpc_code "google.golang.org/genproto/googleapis/rpc/code"
+	"google.golang.org/genproto/googleapis/rpc/code"
+	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 
 	"github.com/twitter/scoot/bazel"
@@ -143,6 +147,116 @@ func ParseExecuteOperation(op *longrunning.Operation) (*remoteexecution.ExecuteO
 	return eom, res, nil
 }
 
+// JSON unmarshalling doesn't work for Operations with nested Results, as they're of unexported type isOperation_Result.
+// Thus, we need custom unmarshalling logic.
+func ExtractOpFromJson(opBytes []byte) (*longrunning.Operation, error) {
+	var opMapTemplate interface{}
+	err := json.Unmarshal(opBytes, &opMapTemplate)
+	if err != nil {
+		return nil, err
+	}
+	opMap := opMapTemplate.(map[string]interface{})
+	op := &longrunning.Operation{}
+	for key, val := range opMap {
+		switch key {
+		case "name":
+			if name, ok := val.(string); !ok {
+				return nil, deserializeErr("name", "string", val)
+			} else {
+				op.Name = name
+			}
+		case "metadata":
+			metadata := &any.Any{}
+			if metadataMap, ok := val.(map[string]interface{}); ok {
+				for mKey, mVal := range metadataMap {
+					switch mKey {
+					case "type_url":
+						if typeUrl, ok := mVal.(string); !ok {
+							return nil, deserializeErr("type_url", "string", mVal)
+						} else {
+							metadata.TypeUrl = typeUrl
+						}
+					case "value":
+						if value, ok := mVal.(string); !ok {
+							return nil, deserializeErr("value", "string", mVal)
+						} else {
+							metadata.Value = []byte(value)
+						}
+					}
+				}
+				op.Metadata = metadata
+			}
+		case "done":
+			if done, ok := val.(bool); !ok {
+				return nil, deserializeErr("done", "bool", val)
+			} else {
+				op.Done = done
+			}
+		case "Result":
+			if opResultMap, ok := val.(map[string]interface{}); ok {
+				for resultKey, resultVal := range opResultMap {
+					switch resultKey {
+					case "Error":
+						opErrorStatus := &status.Status{}
+						opError := &longrunning.Operation_Error{
+							Error: opErrorStatus,
+						}
+						op.Result = opError
+						if errorMap, ok := resultVal.(map[string]interface{}); ok {
+							for errKey, errVal := range errorMap {
+								switch errKey {
+								case "code":
+									if code, ok := errVal.(float64); !ok {
+										return nil, deserializeErr("code", "float64", errVal)
+									} else {
+										opErrorStatus.Code = int32(code)
+									}
+								case "message":
+									if message, ok := errVal.(string); !ok {
+										return nil, deserializeErr("message", "string", errVal)
+									} else {
+										opErrorStatus.Message = message
+									}
+								}
+							}
+						}
+					case "Response":
+						opResponseAny := &any.Any{}
+						opResponse := &longrunning.Operation_Response{
+							Response: opResponseAny,
+						}
+						op.Result = opResponse
+						if responseMap, ok := resultVal.(map[string]interface{}); ok {
+							for responseKey, responseVal := range responseMap {
+								switch responseKey {
+								case "type_url":
+									if typeUrl, ok := responseVal.(string); !ok {
+										return nil, deserializeErr("type_url", "string", responseVal)
+									} else {
+										opResponseAny.TypeUrl = typeUrl
+									}
+								case "value":
+									if value, ok := responseVal.(string); !ok {
+										return nil, deserializeErr("value", "string", responseVal)
+									} else {
+										opResponseAny.Value = []byte(value)
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return op, nil
+}
+
+// Create error for failing to deserialize a field as an expected type
+func deserializeErr(keyName, expectedType string, value interface{}) error {
+	return fmt.Errorf("value for key '%s' was not of type %s. %v: %s", keyName, expectedType, value, reflect.TypeOf(value))
+}
+
 // String conversion for human consumption of Operation's nested data
 func ExecuteOperationToStr(op *longrunning.Operation) string {
 	eom, res, err := ParseExecuteOperation(op)
@@ -156,7 +270,7 @@ func ExecuteOperationToStr(op *longrunning.Operation) string {
 	if res != nil {
 		s += fmt.Sprintf("\tExecResponse:\n")
 		s += fmt.Sprintf("\t\tStatus: %s\n", res.GetStatus())
-		s += fmt.Sprintf("\t\t\tCode: %s\n", google_rpc_code.Code_name[res.GetStatus().GetCode()])
+		s += fmt.Sprintf("\t\t\tCode: %s\n", code.Code_name[res.GetStatus().GetCode()])
 		s += fmt.Sprintf("\t\tCached: %t\n", res.GetCachedResult())
 		s += fmt.Sprintf("\t\tActionResult:\n")
 		s += fmt.Sprintf("\t\t\tExitCode: %d\n", res.GetResult().GetExitCode())

--- a/bazel/execution/client_test.go
+++ b/bazel/execution/client_test.go
@@ -11,13 +11,16 @@ package execution
 //	NOTE: in the generated file, replace the "context" import with "golang.org/x/net/context" and re fmt
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/empty"
-	remoteexecution "github.com/twitter/scoot/bazel/remoteexecution"
+	"github.com/twitter/scoot/bazel/remoteexecution"
 	"golang.org/x/net/context"
 	"google.golang.org/genproto/googleapis/longrunning"
+	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 
 	"github.com/twitter/scoot/bazel/execution/mock_longrunning"
@@ -110,6 +113,64 @@ func TestClientExecute(t *testing.T) {
 	_, _, err = ParseExecuteOperation(op)
 	if err != nil {
 		t.Fatalf("Error parsing resulting Operation: %s", err)
+	}
+}
+
+func TestExtractOpFromJsonError(t *testing.T) {
+	opBytes := []byte(`{"name":"testName","metadata":{"type_url":"type.googleapis.com/build.bazel.remote.execution.v2.ExecuteOperationMetadata","value":"testVal"},"done":true,"Result":{"Error":{"code":1,"message":"CANCELLED"}}}`)
+
+	metadata := &any.Any{
+		TypeUrl: "type.googleapis.com/build.bazel.remote.execution.v2.ExecuteOperationMetadata",
+		Value:   []byte("testVal"),
+	}
+	opErr := &longrunning.Operation_Error{
+		Error: &status.Status{
+			Code:    int32(1),
+			Message: "CANCELLED",
+		},
+	}
+	expOp := &longrunning.Operation{
+		Name:     "testName",
+		Metadata: metadata,
+		Done:     true,
+		Result:   opErr,
+	}
+
+	gotOp, err := ExtractOpFromJson(opBytes)
+	if err != nil {
+		t.Fatalf("Received error extracting operation from json: %s", err)
+	}
+	if !reflect.DeepEqual(gotOp, expOp) {
+		t.Fatalf("Expected gotOp to equal expOp.\ngotOp: %+v\nexpOp: %+v", gotOp, expOp)
+	}
+}
+
+func TestExtractOpFromJsonResponse(t *testing.T) {
+	opBytes := []byte(`{"name":"testName","metadata":{"type_url":"type.googleapis.com/build.bazel.remote.execution.v2.ExecuteOperationMetadata","value":"testVal"},"done":true,"Result":{"Response":{"type_url":"type.googleapis.com/build.bazel.remote.execution.v2.ExecuteOperationMetadata","value":"testVal"}}}`)
+
+	metadata := &any.Any{
+		TypeUrl: "type.googleapis.com/build.bazel.remote.execution.v2.ExecuteOperationMetadata",
+		Value:   []byte("testVal"),
+	}
+	opResp := &longrunning.Operation_Response{
+		Response: &any.Any{
+			TypeUrl: "type.googleapis.com/build.bazel.remote.execution.v2.ExecuteOperationMetadata",
+			Value:   []byte("testVal"),
+		},
+	}
+	expOp := &longrunning.Operation{
+		Name:     "testName",
+		Metadata: metadata,
+		Done:     true,
+		Result:   opResp,
+	}
+
+	gotOp, err := ExtractOpFromJson(opBytes)
+	if err != nil {
+		t.Fatalf("Received error extracting operation from json: %s", err)
+	}
+	if !reflect.DeepEqual(gotOp, expOp) {
+		t.Fatalf("Expected gotOp to equal expOp.\ngotOp: %+v\nexpOp: %+v", gotOp, expOp)
 	}
 }
 

--- a/bazel/execution/client_test.go
+++ b/bazel/execution/client_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/ptypes/empty"
 	remoteexecution "github.com/twitter/scoot/bazel/remoteexecution"
 	"golang.org/x/net/context"
 	"google.golang.org/genproto/googleapis/longrunning"
@@ -57,6 +58,20 @@ func TestClientGetOperation(t *testing.T) {
 	_, _, err = ParseExecuteOperation(op)
 	if err != nil {
 		t.Fatalf("Error parsing resulting Operation: %s", err)
+	}
+}
+
+func TestClientCancelOperation(t *testing.T) {
+	testOperation := "testOp1"
+	cancelReq := &longrunning.CancelOperationRequest{Name: testOperation}
+
+	mockCtrl := gomock.NewController(t)
+	opClientMock := mock_longrunning.NewMockOperationsClient(mockCtrl)
+	opClientMock.EXPECT().CancelOperation(context.Background(), cancelReq).Return(&empty.Empty{}, nil)
+
+	_, err := cancelFromClient(opClientMock, cancelReq)
+	if err != nil {
+		t.Fatalf("Error on CancelOperation: %s", err)
 	}
 }
 

--- a/bazel/execution/utils.go
+++ b/bazel/execution/utils.go
@@ -155,12 +155,9 @@ func runStatusToGoogleRpcStatus(rs *runStatus) *google_rpc_status.Status {
 		return &google_rpc_status.Status{
 			Code: int32(google_rpc_code.Code_INTERNAL),
 		}
-	// NOTE: The API does not indicate that ABORTED as an acceptable error, however
-	// given both the prevalence of Abort behavior in Scoot and the obviousness of the
-	// given status code, it is appropriate that we deviate slightly here.
 	case scoot.RunStatusState_ABORTED:
 		return &google_rpc_status.Status{
-			Code: int32(google_rpc_code.Code_ABORTED),
+			Code: int32(google_rpc_code.Code_CANCELLED),
 		}
 	case scoot.RunStatusState_TIMEDOUT:
 		return &google_rpc_status.Status{

--- a/binaries/bazel-integration/main.go
+++ b/binaries/bazel-integration/main.go
@@ -17,6 +17,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/genproto/googleapis/longrunning"
+	google_rpc_code "google.golang.org/genproto/googleapis/rpc/code"
 
 	"github.com/twitter/scoot/bazel"
 	"github.com/twitter/scoot/bazel/remoteexecution"
@@ -24,6 +25,7 @@ import (
 	"github.com/twitter/scoot/common/log/hooks"
 	"github.com/twitter/scoot/os/temp"
 	"github.com/twitter/scoot/scootapi"
+	"github.com/twitter/scoot/scootapi/setup"
 	"github.com/twitter/scoot/tests/testhelpers"
 )
 
@@ -61,17 +63,110 @@ func main() {
 	// TODO: WaitForClusterToBeReady should wait for CAS/ApiServers too
 	time.Sleep(3 * time.Second)
 
+	testSuccessfulCommand(gopath, clusterCmds)
+	testCancelledCommand(gopath, clusterCmds)
+
+	clusterCmds.Kill()
+}
+
+func installBinaries() error {
+	testhelpers.InstallBinary("bzutil")
+	b, err := exec.Command("sh", "get_fs_util.sh").CombinedOutput()
+	if err != nil {
+		log.Error(string(b))
+	}
+	return err
+}
+
+func testSuccessfulCommand(gopath string, clusterCmds *setup.Cmds) {
+	expectedCommandDigest := remoteexecution.Digest{
+		Hash:      "1b00e10d51c107c1a1f06ebdc09dea3c45e06fd257481d085d4e37566f6a6041",
+		SizeBytes: 76,
+	}
+	expectedActionDigest := remoteexecution.Digest{
+		Hash:      "776f8cae4d90c0719121d4131ea18df38f88e20794e3907bed69195ef986a72f",
+		SizeBytes: 138,
+	}
+	op := testRunCmd(gopath, clusterCmds, 1, expectedCommandDigest, expectedActionDigest)
+	// Get Operation
+	time.Sleep(3 * time.Second)
+	b, err := getOperation(gopath, op.GetName())
+	if err != nil {
+		testhelpers.KillAndExit1(clusterCmds, err)
+	}
+	json.Unmarshal(b, op)
+	if !op.GetDone() {
+		testhelpers.KillAndExit1(clusterCmds, fmt.Errorf("Expected operation to be Done. Op: %v", op))
+	}
+	// TODO: propagate op.Result through json Unmarshaling and verify op.Response is set per contract defined at
+	// https://github.com/googleapis/go-genproto/blob/c506a9f9061087022822e8da603a52fc387115a8/googleapis/longrunning/operations.pb.go#L50
+	// if op.GetResponse() == nil {
+	// 	testhelpers.KillAndExit1(clusterCmds, fmt.Errorf("Expected result to be set. Op: %v", op))
+	// }
+	log.Info("Operation completed successfully")
+}
+
+func testCancelledCommand(gopath string, clusterCmds *setup.Cmds) {
+	expectedCommandDigest := remoteexecution.Digest{
+		Hash:      "0392024bf028c9fd456824d64aacd8937679c451ff512c7a43da72680bf532fd",
+		SizeBytes: 78,
+	}
+	expectedActionDigest := remoteexecution.Digest{
+		Hash:      "19ca48544f8ad500bf07b0ed06ec0fbe32f9474325d381a81a1acd23ccee52af",
+		SizeBytes: 138,
+	}
+	op := testRunCmd(gopath, clusterCmds, 100, expectedCommandDigest, expectedActionDigest)
+
+	// Get Operation
+	b, err := getOperation(gopath, op.GetName())
+	if err != nil {
+		testhelpers.KillAndExit1(clusterCmds, err)
+	}
+	json.Unmarshal(b, op)
+	if op.GetDone() {
+		testhelpers.KillAndExit1(clusterCmds, fmt.Errorf("Expected operation to not be Done. Op: %v", op))
+	}
+
+	// Cancel Operation
+	_, err = cancelOperation(gopath, op.GetName())
+	if err != nil {
+		testhelpers.KillAndExit1(clusterCmds, fmt.Errorf("Unable to cancel operation: %s", err))
+	}
+
+	// Get Operation and verify it was cancelled
+	time.Sleep(3 * time.Second)
+	b, err = getOperation(gopath, op.GetName())
+	log.Errorf("b: %s", string(b))
+	if err != nil {
+		testhelpers.KillAndExit1(clusterCmds, err)
+	}
+	json.Unmarshal(b, op)
+	if !op.GetDone() {
+		testhelpers.KillAndExit1(clusterCmds, fmt.Errorf("Expected operation to be Done. Op: %v", op))
+	}
+	// TODO: propagate op.Result through json Unmarshaling and verify op.Error is set per contract defined at
+	// https://github.com/googleapis/go-genproto/blob/c506a9f9061087022822e8da603a52fc387115a8/googleapis/longrunning/operations.pb.go#L50
+	// if op.GetError() == nil {
+	// 	testhelpers.KillAndExit1(clusterCmds, fmt.Errorf("Expected result to be of type Operation_Error, was %+v", op.GetResult()))
+	// }
+	// if op.GetError().GetCode() != int32(google_rpc_code.Code_CANCELLED) {
+	// 	testhelpers.KillAndExit1(clusterCmds, fmt.Errorf("op.Error.Code to be %d, was %d", google_rpc_code.Code_CANCELLED, op.GetError().GetCode()))
+	// }
+	// if op.GetError().GetMessage() != "CANCELLED" {
+	// 	testhelpers.KillAndExit1(clusterCmds, fmt.Errorf("op.Error.Message to be 'CANCELLED', was %s", op.GetError().GetMessage()))
+	// }
+
+	log.Info("Operation cancelled successfully")
+}
+
+func testRunCmd(gopath string, clusterCmds *setup.Cmds, timeToSleep int, expectedCommandDigest, expectedActionDigest remoteexecution.Digest) *longrunning.Operation {
 	// Upload Command
-	b, err := uploadCommand(gopath)
+	b, err := uploadCommand(gopath, timeToSleep)
 	if err != nil {
 		testhelpers.KillAndExit1(clusterCmds, err)
 	}
 	commandDigest := &remoteexecution.Digest{}
 	json.Unmarshal(b, commandDigest)
-	expectedCommandDigest := remoteexecution.Digest{
-		Hash:      "1b00e10d51c107c1a1f06ebdc09dea3c45e06fd257481d085d4e37566f6a6041",
-		SizeBytes: 76,
-	}
 
 	if err = assertEqual(*commandDigest, expectedCommandDigest); err != nil {
 		testhelpers.KillAndExit1(clusterCmds, err)
@@ -104,10 +199,6 @@ func main() {
 	}
 	actionDigest := &remoteexecution.Digest{}
 	json.Unmarshal(b, actionDigest)
-	expectedActionDigest := remoteexecution.Digest{
-		Hash:      "776f8cae4d90c0719121d4131ea18df38f88e20794e3907bed69195ef986a72f",
-		SizeBytes: 138,
-	}
 	if err = assertEqual(*actionDigest, expectedActionDigest); err != nil {
 		testhelpers.KillAndExit1(clusterCmds, err)
 	}
@@ -119,30 +210,11 @@ func main() {
 	operation := &longrunning.Operation{}
 	json.Unmarshal(b, operation)
 	log.Infof("Operation executing: %v", operation)
-	// Get Operation
-	time.Sleep(3 * time.Second)
-	b, err = getOperation(gopath, operation.GetName())
-	if err != nil {
-		testhelpers.KillAndExit1(clusterCmds, err)
-	}
-	json.Unmarshal(b, operation)
-	if !operation.GetDone() {
-		testhelpers.KillAndExit1(clusterCmds, fmt.Errorf("Expected operation to be Done. Op: %v", operation))
-	}
-	clusterCmds.Kill()
+	return operation
 }
 
-func installBinaries() error {
-	testhelpers.InstallBinary("bzutil")
-	b, err := exec.Command("sh", "get_fs_util.sh").CombinedOutput()
-	if err != nil {
-		log.Error(string(b))
-	}
-	return err
-}
-
-func uploadCommand(gopath string) ([]byte, error) {
-	return exec.Command(gopath+"/bin/bzutil", "upload_command", "--json", "--cas_addr=localhost:12100", "--output_files=/output/f1", "--output_dirs=/output/d1,/output/subdir/d2", "--platform_props=JDK_SYMLINK=.jvm", "sleep", "1").Output()
+func uploadCommand(gopath string, timeToSleep int) ([]byte, error) {
+	return exec.Command(gopath+"/bin/bzutil", "upload_command", "--json", "--cas_addr=localhost:12100", "--output_files=/output/f1", "--output_dirs=/output/d1,/output/subdir/d2", "--platform_props=JDK_SYMLINK=.jvm", "sleep", fmt.Sprintf("%d", timeToSleep)).Output()
 }
 
 func saveDirectory(gopath string) ([]byte, error) {
@@ -167,6 +239,10 @@ func execute(gopath, actionDigest string) ([]byte, error) {
 
 func getOperation(gopath, name string) ([]byte, error) {
 	return exec.Command(gopath+"/bin/bzutil", "get_operation", "--json", fmt.Sprintf("--name=%s", name)).Output()
+}
+
+func cancelOperation(gopath, name string) ([]byte, error) {
+	return exec.Command(gopath+"/bin/bzutil", "cancel_operation", "--json", fmt.Sprintf("--name=%s", name)).Output()
 }
 
 func assertEqual(recvd, expected remoteexecution.Digest) error {

--- a/binaries/bazel-integration/main.go
+++ b/binaries/bazel-integration/main.go
@@ -17,7 +17,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/genproto/googleapis/longrunning"
-	google_rpc_code "google.golang.org/genproto/googleapis/rpc/code"
+	// google_rpc_code "google.golang.org/genproto/googleapis/rpc/code"
 
 	"github.com/twitter/scoot/bazel"
 	"github.com/twitter/scoot/bazel/remoteexecution"

--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -413,6 +413,13 @@ const (
 	BzGetOpFailureCounter = "bzGetOpFailureCounter"
 	BzGetOpLatency_ms     = "bzGetOpLatency_ms"
 
+	/*
+		Longrunning CancelOperation API metrics emitted by Scheduler
+	*/
+	BzCancelOpSuccessCounter = "bzCancelOpSuccessCounter"
+	BzCancelOpFailureCounter = "bzCancelOpFailureCounter"
+	BzCancelOpLatency_ms     = "bzCancelOpLatency_ms"
+
 	/****************************** Worker/Invoker Execution Timings ***************************/
 	/*
 		Execution metadata timing metrics emitted by Worker.

--- a/scootapi/server/api/kill_job_test.go
+++ b/scootapi/server/api/kill_job_test.go
@@ -57,7 +57,7 @@ func makeMockSagaCoordinator(t *testing.T) saga.SagaCoordinator {
 func makeMockScheduler(t *testing.T) *scheduler.MockScheduler {
 
 	scheduler := scheduler.NewMockScheduler(mockCtrl)
-	scheduler.EXPECT().KillJob("err").Return(fmt.Errorf("saw kil job request in scheduler"))
+	scheduler.EXPECT().KillJob("err").Return(fmt.Errorf("saw kill job request in scheduler"))
 	scheduler.EXPECT().KillJob("1").Return(nil)
 
 	return scheduler


### PR DESCRIPTION
Problem

Bazel API CancelOperation is not currently supported in Scoot

Solution

Implement CancelOperation

Result

Clients can send CancelOperation requests to abort in progress longrunning Operations
