### PR TITLE
Cancel for Checkouter/Ingester, implement for bztree

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -57,7 +57,7 @@
 [submodule "vendor/github.com/sirupsen/logrus"]
 	path = vendor/github.com/sirupsen/logrus
 	url = https://github.com/sirupsen/logrus
-    branch = 1ed61965b9e594bf37539680d7f63eccd060314f
+    branch = 839c75faf7f98a33d445d181f3018b5c3409a45e
 [submodule "vendor/github.com/bazelbuild/remote-apis"]
 	path = vendor/github.com/bazelbuild/remote-apis
 	url = https://github.com/bazelbuild/remote-apis

--- a/runner/execer/execer.go
+++ b/runner/execer/execer.go
@@ -11,7 +11,6 @@ import (
 // It's at the level of os/exec, not exec-as-a-service.
 
 // Memory in bytes.
-//FIXME(jschiller) arbitrary commands can spawn dissociated/untracked child processes (ppid=1)
 type Memory uint64
 
 type Command struct {
@@ -55,6 +54,7 @@ type Execer interface {
 	Exec(command Command) (Process, error)
 }
 
+// TODO why a separate interface from Execer?
 type Process interface {
 	// Blocks until the process terminates.
 	Wait() ProcessStatus

--- a/runner/execer/execer.go
+++ b/runner/execer/execer.go
@@ -54,7 +54,7 @@ type Execer interface {
 	Exec(command Command) (Process, error)
 }
 
-// TODO why a separate interface from Execer?
+// TODO why not include directly in Execer?
 type Process interface {
 	// Blocks until the process terminates.
 	Wait() ProcessStatus
@@ -63,6 +63,7 @@ type Process interface {
 	Abort() ProcessStatus
 }
 
+// TODO when are these valid in what cases?
 type ProcessStatus struct {
 	State    ProcessState
 	ExitCode int

--- a/runner/execer/os/constants.go
+++ b/runner/execer/os/constants.go
@@ -1,0 +1,7 @@
+package os
+
+const (
+	bytesToKB = 1024
+
+	AbortTimeoutSec = 10
+)

--- a/runner/execer/os/easy_test.go
+++ b/runner/execer/os/easy_test.go
@@ -101,10 +101,11 @@ func TestMemUsage(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
+	process.(*osProcess).ats = 1
 	defer process.Abort()
 	// Check for growing memory usage at [1.5, 3]s. Then check that the usage is between a reasonable min/max.
 	prevUsage := 0
-	sleepDuration := 1500 * time.Millisecond
+	sleepDuration := 500 * time.Millisecond
 	for i := 0; i < 2; i++ {
 		time.Sleep(sleepDuration)
 		if newUsage, err := e.memUsage(process.(*osProcess).cmd.Process.Pid); err != nil {
@@ -115,8 +116,8 @@ func TestMemUsage(t *testing.T) {
 			prevUsage = int(newUsage)
 		}
 	}
-	if prevUsage < 15*1024*1024 {
-		t.Fatalf("Expected usage to be at least 20MB, was: %dB", prevUsage)
+	if prevUsage < 5*1024*1024 {
+		t.Fatalf("Expected usage to be at least 5MB, was: %dB", prevUsage)
 	}
 	if prevUsage > 50*1024*1024 {
 		t.Fatalf("Expected usage to be less than 50MB, was: %dB", prevUsage)
@@ -143,6 +144,7 @@ func TestMemCap(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
+	process.(*osProcess).ats = 1
 	defer process.Abort()
 	pid := process.(*osProcess).cmd.Process.Pid
 	var usage execer.Memory

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -37,6 +37,7 @@ type WriterDelegater interface {
 	WriterDelegate() io.Writer
 }
 
+// Implements runner/execer.Execer
 type osExecer struct {
 	// Best effort monitoring of command to kill it if resident memory usage exceeds this cap. Ignored if zero.
 	memCap execer.Memory
@@ -44,6 +45,7 @@ type osExecer struct {
 	pg     procGetter
 }
 
+// Implements runner/execer.Process
 type osProcess struct {
 	cmd    *exec.Cmd
 	wg     *sync.WaitGroup

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -231,7 +231,7 @@ func (e *osExecer) monitorMem(p *osProcess, memCh chan execer.ProcessStatus) {
 						"tag":    p.Tag,
 						"jobID":  p.JobID,
 						"taskID": p.TaskID,
-					}).Debugf("ps after increasing mem_cap utilization for pid %d", pid)
+					}).Tracef("ps after increasing mem_cap utilization for pid %d", pid)
 				cancel()
 
 				for memUsagePct > reportThresholds[thresholdsIdx] {
@@ -356,7 +356,7 @@ func (p *osProcess) Wait() (result execer.ProcessStatus) {
 			"ps":     string(ps),
 			"err":    errDbg,
 			"errCtx": ctx.Err(),
-		}).Debugf("Current ps for pid %d", pid)
+		}).Tracef("Current ps for pid %d", pid)
 	cancel()
 
 	if p.result != nil {

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -187,6 +187,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 	}()
 
 	select {
+	// TODO CLEANUPS REQUIRED (above Filer.Checkout operation)
 	case <-abortCh:
 		go func() {
 			if err := <-checkoutCh; err != nil {
@@ -444,6 +445,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 				}
 			}()
 
+			// TODO CLEANUP REQUIRED (Filer.Ingest call above) (ingestCh)
 			// Meaningful to support Abort after execer has completed?
 			var snapshotID string
 			select {
@@ -489,6 +491,8 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 				}
 			}()
 
+			// TODO CLEANUP REQUIRED (postProcessBazel call above) (ingestCh)
+			// need to, because this can call Ingest (fs_util)
 			// Meaningful to support Abort after execer has completed?
 			var actionResult *bazelapi.ActionResult
 			select {

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -187,9 +187,11 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 	}()
 
 	select {
-	// TODO CLEANUPS REQUIRED (above Filer.Checkout operation)
 	case <-abortCh:
 		go func() {
+			if err := inv.filerMap[runType].Filer.CancelCheckout(); err != nil {
+				log.Errorf("Error canceling checkout: %s", err)
+			}
 			if err := <-checkoutCh; err != nil {
 				// If there was an error there should be no lingering gitdb locks, so return.
 				return
@@ -279,8 +281,9 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 	marker := "###########################################\n###########################################\n"
 	format := "%s\n\nDate: %v\nOut: %s\tErr: %s\tOutErr: %s\tCmd:\n%v\n\n%s\n\n\nSCOOT_CMD_LOG\n"
 	header := fmt.Sprintf(format, marker, time.Now(), stdout.URI(), stderr.URI(), stdlog.URI(), cmd, marker)
-	// TODO We don't add headers for Bazel. Not clear if a switch for this would come at the Worker level
-	// (via Invoker -> QueueRunner construction) or Command level (job requestor specifies in e.g. a PlatformProperty)
+	// NOTE We don't add headers for Bazel.
+	// If we wanted to allow optionally, a switch for this would come either at the Worker level
+	// (via Invoker -> QueueRunner construction), or the Command level (job requestor specifies in e.g. a PlatformProperty)
 
 	// Processing/setup post checkout before execution
 	switch runType {
@@ -445,11 +448,12 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 				}
 			}()
 
-			// TODO CLEANUP REQUIRED (Filer.Ingest call above) (ingestCh)
-			// Meaningful to support Abort after execer has completed?
 			var snapshotID string
 			select {
 			case <-abortCh:
+				if err := inv.filerMap[runType].Filer.CancelIngest(); err != nil {
+					log.Errorf("Error canceling ingest: %s", err)
+				}
 				return runner.AbortStatus(id, tags.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID, Tag: cmd.Tag})
 			case res := <-ingestCh:
 				switch res.(type) {
@@ -491,12 +495,13 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 				}
 			}()
 
-			// TODO CLEANUP REQUIRED (postProcessBazel call above) (ingestCh)
-			// need to, because this can call Ingest (fs_util)
-			// Meaningful to support Abort after execer has completed?
 			var actionResult *bazelapi.ActionResult
 			select {
 			case <-abortCh:
+				// postProcessBazel actions here can be calling Filer.Ingest on Bazel OutputFiles/Dirs
+				if err := inv.filerMap[runType].Filer.CancelIngest(); err != nil {
+					log.Errorf("Error canceling ingest: %s", err)
+				}
 				return runner.AbortStatus(id, tags.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID, Tag: cmd.Tag})
 			case res := <-ingestCh:
 				switch res.(type) {

--- a/snapshot/bazel/bz_tree.go
+++ b/snapshot/bazel/bz_tree.go
@@ -115,8 +115,22 @@ func (bc bzCommand) runCmd(args []string) ([]byte, []byte, error) {
 		}
 	}
 
-	// TODO stop using Run - use Start() and then Wait()?
+	// TODO stop using Run - use a runner/execer/os execer?
+	// This starts an internal channel
+	// Cancel handlers send msg onto cancel channel, signalling os execer, etc.
 	// what is the abort mechanism? Filers don't have a checkout abort...
+	// Test
+	//
+	// BzFiler gets an Execer, AbortCh, mutex
+	//
+	// craft an execer/Command
+	// Wait on a processCh
+	// Open an abortCh and wait on it, too. Cancel's signal abortCh if not nil
+	// Do any assoc cleanups
+	// Bytes buffers are OK output, need to interpret ProcessState exit for return value
+	//
+	// Cancel outside of running Exec is a no-op (no abortCh open)
+	//	creation/closing/sending of abortCh should be mutexed
 	log.Debugf("%s %s", fsUtilCmd, args)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/snapshot/bazel/bz_tree.go
+++ b/snapshot/bazel/bz_tree.go
@@ -115,6 +115,8 @@ func (bc bzCommand) runCmd(args []string) ([]byte, []byte, error) {
 		}
 	}
 
+	// TODO stop using Run - use Start() and then Wait()?
+	// what is the abort mechanism? Filers don't have a checkout abort...
 	log.Debugf("%s %s", fsUtilCmd, args)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/snapshot/bazel/bz_tree.go
+++ b/snapshot/bazel/bz_tree.go
@@ -4,38 +4,44 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
+	"sync"
 
 	log "github.com/sirupsen/logrus"
 
 	"github.com/twitter/scoot/bazel"
 	"github.com/twitter/scoot/common/dialer"
+	"github.com/twitter/scoot/runner/execer"
+	osexecer "github.com/twitter/scoot/runner/execer/os"
 )
 
 // Implements snapshot/bazel/bzTree
 type bzCommand struct {
 	localStorePath string
 	casResolver    dialer.Resolver
-	// Currently, uses resolver for each underlying runCmd. In the future, we may
-	// want to limit the number of calls to Resolve if these happen too frequently.
-	//
+
 	// Not yet implemented:
 	// bypassLocalStore bool
 	// skipServer bool
+
+	// Fields for managing underlying invocations of the fs_util tool
+	execer  execer.Execer
+	mu      sync.Mutex
+	abortCh chan struct{}
 }
 
-func makeBzCommand(storePath string, resolver dialer.Resolver) bzCommand {
-	return bzCommand{
+func makeBzCommand(storePath string, resolver dialer.Resolver) *bzCommand {
+	return &bzCommand{
 		localStorePath: storePath,
 		casResolver:    resolver,
+		execer:         osexecer.NewExecer(),
 	}
 }
 
 // Saves the file/dir specified by path using the fsUtilCmd & validates the id format
 // Note: if there are any "irregular" files in path or path's parent dir (root) - e.g. *.sock
 // files, etc. - fs_util will fail to expand globs.
-func (bc bzCommand) save(path string) (string, error) {
+func (bc *bzCommand) save(path string) (string, error) {
 	fileType, err := getFileType(path)
 	if err != nil {
 		return "", err
@@ -50,13 +56,12 @@ func (bc bzCommand) save(path string) (string, error) {
 	}
 	log.Info(args)
 
-	stdout, _, err := bc.runCmd(args)
+	stdout, _, st, err := bc.runCmd(args)
 	if err != nil {
-		exitError, ok := err.(*exec.ExitError)
-		if ok {
-			return "", fmt.Errorf("Error: %s. Stderr: %s", err, exitError.Stderr)
-		}
-		return "", err
+		return "", fmt.Errorf("Error running command: %s", err)
+	}
+	if st.State != execer.COMPLETE || st.ExitCode != 0 || st.Error != "" {
+		return "", fmt.Errorf("Error execing save. ProcessStatus: %v", st)
 	}
 
 	err = validateFsUtilSaveOutput(stdout)
@@ -79,19 +84,21 @@ func (bc bzCommand) save(path string) (string, error) {
 }
 
 // Materializes the digest identified by sha in dir using the fsUtilCmd
-func (bc bzCommand) materialize(sha string, size int64, dir string) error {
+func (bc *bzCommand) materialize(sha string, size int64, dir string) error {
 	// short circuit if the input is empty, but create the target dir as fs_util would do
 	if sha == bazel.EmptySha {
 		return os.Mkdir(dir, 0777)
 	}
 
-	_, stderr, err := bc.runCmd([]string{fsUtilCmdDirectory, fsUtilCmdMaterialize, sha, strconv.FormatInt(size, 10), dir})
+	_, stderr, st, err := bc.runCmd([]string{fsUtilCmdDirectory, fsUtilCmdMaterialize, sha, strconv.FormatInt(size, 10), dir})
 	if err != nil {
-		exitError, ok := err.(*exec.ExitError)
-		if ok {
-			return &CheckoutNotExistError{Err: fmt.Sprintf("Error: %s. Stderr: %s", err, exitError.Stderr)}
-		}
-		return err
+		return fmt.Errorf("Error running command: %s", err)
+	}
+	if st.State == execer.COMPLETE && st.ExitCode != 0 {
+		// Interpret normal run with non-0 exit as "this didn't exist"
+		return &CheckoutNotExistError{Err: fmt.Sprintf("Error -  ProcessStatus: %v", st)}
+	} else if st.State != execer.COMPLETE || st.ExitCode != 0 || st.Error != "" {
+		return fmt.Errorf("Error execing materialize. ProcessStatus: %v", st)
 	}
 
 	// temporarily dump stderr to program's stderr
@@ -100,11 +107,22 @@ func (bc bzCommand) materialize(sha string, size int64, dir string) error {
 	return nil
 }
 
-// Runs fsUtilCmd as an os/exec.Cmd with appropriate flags
-func (bc bzCommand) runCmd(args []string) ([]byte, []byte, error) {
+// send a signal on the abortCh if there is an exec running
+func (bc *bzCommand) cancel() error {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+
+	if bc.abortCh != nil {
+		bc.abortCh <- struct{}{}
+	}
+	return nil
+}
+
+// Runs fsUtilCmd via an execer with appropriate flags
+func (bc *bzCommand) runCmd(args []string) ([]byte, []byte, execer.ProcessStatus, error) {
 	serverAddrs, err := bc.casResolver.ResolveMany(maxResolveToFSUtil)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, execer.ProcessStatus{}, err
 	}
 
 	// localStorePath required, add serverAddrs if resolved
@@ -113,36 +131,65 @@ func (bc bzCommand) runCmd(args []string) ([]byte, []byte, error) {
 		for _, addr := range serverAddrs {
 			args = append([]string{fsUtilCmdServerAddr, addr}, args...)
 		}
+		log.Debugf("%s %s", fsUtilCmd, args)
 	}
 
-	// TODO stop using Run - use a runner/execer/os execer?
-	// This starts an internal channel
-	// Cancel handlers send msg onto cancel channel, signalling os execer, etc.
-	// what is the abort mechanism? Filers don't have a checkout abort...
-	// Test
-	//
-	// BzFiler gets an Execer, AbortCh, mutex
-	//
-	// craft an execer/Command
-	// Wait on a processCh
-	// Open an abortCh and wait on it, too. Cancel's signal abortCh if not nil
-	// Do any assoc cleanups
-	// Bytes buffers are OK output, need to interpret ProcessState exit for return value
-	//
-	// Cancel outside of running Exec is a no-op (no abortCh open)
-	//	creation/closing/sending of abortCh should be mutexed
-	log.Debugf("%s %s", fsUtilCmd, args)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	cmd := exec.Command(fsUtilCmd, args...)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err = cmd.Run()
-	return stdout.Bytes(), stderr.Bytes(), err
+	argv := append([]string{fsUtilCmd}, args...)
+
+	cmd := execer.Command{
+		Argv:   argv,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+
+	st := bc.exec(cmd)
+
+	return stdout.Bytes(), stderr.Bytes(), st, nil
+}
+
+func (bc *bzCommand) exec(c execer.Command) execer.ProcessStatus {
+	bc.startupCh()
+	p, err := bc.execer.Exec(c)
+
+	if err != nil {
+		return execer.ProcessStatus{
+			State:    execer.FAILED,
+			ExitCode: 0,
+			Error:    fmt.Sprintf("failed to exec command: %s", err)}
+	}
+
+	processCh := make(chan execer.ProcessStatus, 1)
+	go func() { processCh <- p.Wait() }()
+	var st execer.ProcessStatus
+
+	select {
+	case st = <-processCh:
+	case <-bc.abortCh:
+		st = p.Abort()
+	}
+
+	bc.shutdownCh()
+	return st
+}
+
+func (bc *bzCommand) startupCh() {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+	bc.abortCh = make(chan struct{})
+}
+
+func (bc *bzCommand) shutdownCh() {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+	close(bc.abortCh)
+	bc.abortCh = nil
 }
 
 // Noop bzTree for stub testing
 type noopBzTree struct{}
 
-func (bc noopBzTree) save(path string) (string, error)                     { return "", nil }
-func (bc noopBzTree) materialize(sha string, size int64, dir string) error { return nil }
+func (bc *noopBzTree) save(path string) (string, error)                     { return "", nil }
+func (bc *noopBzTree) materialize(sha string, size int64, dir string) error { return nil }
+func (bc *noopBzTree) cancel() error                                        { return nil }

--- a/snapshot/bazel/checkouter.go
+++ b/snapshot/bazel/checkouter.go
@@ -67,7 +67,6 @@ func (bf *BzFiler) CheckoutAt(id string, dir string) (snapshot.Checkout, error) 
 	return co, nil
 }
 
-// TODO ch to cancel in flight bztree ops
 func (bf *BzFiler) CancelCheckout() error {
-	return nil
+	return bf.tree.cancel()
 }

--- a/snapshot/bazel/checkouter.go
+++ b/snapshot/bazel/checkouter.go
@@ -66,3 +66,8 @@ func (bf *BzFiler) CheckoutAt(id string, dir string) (snapshot.Checkout, error) 
 
 	return co, nil
 }
+
+// TODO ch to cancel in flight bztree ops
+func (bf *BzFiler) CancelCheckout() error {
+	return nil
+}

--- a/snapshot/bazel/filer.go
+++ b/snapshot/bazel/filer.go
@@ -2,9 +2,11 @@ package bazel
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/twitter/scoot/common/dialer"
 	"github.com/twitter/scoot/os/temp"
+	"github.com/twitter/scoot/runner/execer"
 	"github.com/twitter/scoot/snapshot"
 	"github.com/twitter/scoot/snapshot/snapshots"
 )
@@ -68,6 +70,12 @@ type BzFiler struct {
 	// an underlying tool that makes CAS requests on our behalf during Checkout and Ingest.
 	CASResolver dialer.Resolver
 	updater     snapshot.Updater
+
+	treeExecer execer.Execer
+
+	// synchronization
+	treeMutex sync.Mutex
+	abortCh ...
 }
 
 // Interface that specifies actions on directory tree structures for Bazel

--- a/snapshot/bazel/filer_test.go
+++ b/snapshot/bazel/filer_test.go
@@ -29,7 +29,7 @@ func setup() (*temp.TempDir, *BzFiler) {
 		os.Exit(1)
 	}
 	bf := &BzFiler{
-		tree: noopBzTree{},
+		tree: &noopBzTree{},
 		tmp:  tmp,
 	}
 	return tmp, bf

--- a/snapshot/bazel/fs_util_test.go
+++ b/snapshot/bazel/fs_util_test.go
@@ -241,8 +241,12 @@ func TestCancelOperation(t *testing.T) {
 		doneCh <- bc.exec(cmd)
 	}()
 
+	// simplest way to ensure cancel gets run after exec actually starts
 	go func() {
-		bc.cancel()
+		for {
+			bc.cancel()
+			time.Sleep(1 * time.Millisecond)
+		}
 	}()
 
 	select {

--- a/snapshot/bazel/fs_util_test.go
+++ b/snapshot/bazel/fs_util_test.go
@@ -5,11 +5,14 @@ package bazel
 import (
 	"os/exec"
 	"testing"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
 	"github.com/twitter/scoot/bazel"
 	"github.com/twitter/scoot/common/log/hooks"
+	"github.com/twitter/scoot/runner/execer"
+	"github.com/twitter/scoot/runner/execer/execers"
 )
 
 // uses test vars and setup/teardown defined in filer_test.go
@@ -214,5 +217,40 @@ func TestMaterializeEmptyDir(t *testing.T) {
 	}
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+// test cancellation functionality
+func TestCancelOperation(t *testing.T) {
+	_, err := tmpTest.TempDir("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bf := makeTestingFiler()
+	// Override bf's bzCommand's execer with a sim execer
+	bc := bf.tree.(*bzCommand)
+	bc.execer = execers.NewSimExecer()
+
+	cmd := execer.Command{
+		Argv: []string{"pause", "complete 0"},
+	}
+	doneCh := make(chan execer.ProcessStatus)
+
+	go func() {
+		doneCh <- bc.exec(cmd)
+	}()
+
+	go func() {
+		bc.cancel()
+	}()
+
+	select {
+	case st := <-doneCh:
+		if st.State != execer.FAILED {
+			t.Fatalf("Expected state after Abort: %s, got: %s", execer.FAILED, st.State)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Hit unexpected timeout waiting for bzCommand exec to finish/abort")
 	}
 }

--- a/snapshot/bazel/ingester.go
+++ b/snapshot/bazel/ingester.go
@@ -26,7 +26,6 @@ func (bf *BzFiler) IngestMap(srcToDest map[string]string) (string, error) {
 	return "", fmt.Errorf(errMsg)
 }
 
-// TODO cancel ch to inflight bztree ops
 func (bf *BzFiler) CancelIngest() error {
-	return nil
+	return bf.tree.cancel()
 }

--- a/snapshot/bazel/ingester.go
+++ b/snapshot/bazel/ingester.go
@@ -25,3 +25,8 @@ func (bf *BzFiler) IngestMap(srcToDest map[string]string) (string, error) {
 	log.Error(errMsg)
 	return "", fmt.Errorf(errMsg)
 }
+
+// TODO cancel ch to inflight bztree ops
+func (bf *BzFiler) CancelIngest() error {
+	return nil
+}

--- a/snapshot/db.go
+++ b/snapshot/db.go
@@ -58,10 +58,12 @@ type Reader interface {
 	ExportGitCommit(id ID, exportRepo *repo.Repository) (commit string, err error)
 }
 
+// TODO remove this abstraction, or consolidate it with Filer
 // DB is the full read-write Snapshot Database, allowing creation and reading of Snapshots,
 // and updating of the underlying DB resource.
 type DB interface {
 	Creator
 	Reader
 	Updater
+	Cancel() error // Request to cancel in-progress operations
 }

--- a/snapshot/filer.go
+++ b/snapshot/filer.go
@@ -26,6 +26,8 @@ type Checkouter interface {
 
 	// Create checkout in a caller controlled dir.
 	CheckoutAt(id string, dir string) (Checkout, error)
+
+	// TODO Cancel() interface? (would need for Ingester too)
 }
 
 // Checkout represents one checkout of a Snapshot.

--- a/snapshot/filer.go
+++ b/snapshot/filer.go
@@ -27,7 +27,8 @@ type Checkouter interface {
 	// Create checkout in a caller controlled dir.
 	CheckoutAt(id string, dir string) (Checkout, error)
 
-	// TODO Cancel() interface? (would need for Ingester too)
+	// Request to cancel any current Checkouter operations
+	CancelCheckout() error
 }
 
 // Checkout represents one checkout of a Snapshot.
@@ -53,6 +54,9 @@ type Ingester interface {
 	// Takes a mapping of source paths to be copied into corresponding destination directories.
 	// Source paths are absolute, and destination directories are relative to Checkout root.
 	IngestMap(srcToDest map[string]string) (id string, err error)
+
+	// Request to cancel any current Ingester operations
+	CancelIngest() error
 }
 
 const NoDuration time.Duration = time.Duration(0)
@@ -93,6 +97,10 @@ func (dba *dbAdapter) CheckoutAt(id string, dir string) (Checkout, error) {
 	}
 }
 
+func (dba *dbAdapter) CancelCheckout() error {
+	return nil
+}
+
 func (dba *dbAdapter) Ingest(path string) (id string, err error) {
 	if ident, err := dba.db.IngestDir(path); err != nil {
 		return "", err
@@ -105,6 +113,10 @@ func (dba *dbAdapter) IngestMap(srcToDest map[string]string) (string, error) {
 	errMsg := "Not implemented"
 	log.Error(errMsg)
 	return "", fmt.Errorf(errMsg)
+}
+
+func (dba *dbAdapter) CancelIngest() error {
+	return nil
 }
 
 func (dba *dbAdapter) Update() error {

--- a/snapshot/git/gitdb/db.go
+++ b/snapshot/git/gitdb/db.go
@@ -480,3 +480,8 @@ func (db *DB) StreamName() string {
 	}
 	return ""
 }
+
+// Unimplemented
+func (db *DB) Cancel() error {
+	return nil
+}

--- a/snapshot/git/gitfiler/checkouter.go
+++ b/snapshot/git/gitfiler/checkouter.go
@@ -88,9 +88,15 @@ func (c *Checkouter) CheckoutAt(id string, dir string) (co snapshot.Checkout, er
 	return &UnmanagedCheckout{id: id, dir: dir}, nil
 }
 
+// Unimplemented
+func (c *Checkouter) CancelCheckout() error {
+	return nil
+}
+
 // Implement noop ingest/update so this Checkouter can be passed around as a Filer.
 func (c *Checkouter) Ingest(string) (string, error)               { return "", nil }
 func (c *Checkouter) IngestMap(map[string]string) (string, error) { return "", nil }
+func (c *Checkouter) CancelIngest() error                         { return nil }
 func (c *Checkouter) Update() error                               { return nil }
 func (c *Checkouter) UpdateInterval() time.Duration               { return snapshot.NoDuration }
 func (c *Checkouter) AsFiler() snapshot.Filer                     { return c }

--- a/snapshot/snapshots/fake_checkouter.go
+++ b/snapshot/snapshots/fake_checkouter.go
@@ -29,6 +29,10 @@ func (c *noopCheckouter) CheckoutAt(id string, dir string) (snapshot.Checkout, e
 	}, nil
 }
 
+func (c *noopCheckouter) CancelCheckout() error {
+	return nil
+}
+
 // MakeTempCheckouter creates a new Checkouter that always checks out by creating a new, empty temp dir
 func MakeTempCheckouter(tmp *temp.TempDir) snapshot.Checkouter {
 	return &tempCheckouter{tmp: tmp}
@@ -51,6 +55,10 @@ func (c *tempCheckouter) CheckoutAt(id string, dir string) (snapshot.Checkout, e
 		path: dir,
 		id:   id,
 	}, nil
+}
+
+func (c *tempCheckouter) CancelCheckout() error {
+	return nil
 }
 
 type staticCheckout struct {

--- a/snapshot/snapshots/fake_filer.go
+++ b/snapshot/snapshots/fake_filer.go
@@ -94,6 +94,10 @@ func (t *tempFiler) IngestMap(srcToDest map[string]string) (id string, err error
 	return
 }
 
+func (t *tempFiler) CancelIngest() error {
+	return nil
+}
+
 func (t *tempFiler) Checkout(id string) (snapshot.Checkout, error) {
 	dir, err := t.tmp.TempDir("checkout-" + id + "__")
 	if err != nil {
@@ -123,6 +127,10 @@ func (t *tempFiler) CheckoutAt(id string, dir string) (snapshot.Checkout, error)
 	}, nil
 }
 
+func (t *tempFiler) CancelCheckout() error {
+	return nil
+}
+
 func (t *tempFiler) Update() error { return nil }
 
 func (t *tempFiler) UpdateInterval() time.Duration { return snapshot.NoDuration }
@@ -140,6 +148,9 @@ func (n *NoopIngester) Ingest(string) (string, error) {
 }
 func (n *NoopIngester) IngestMap(map[string]string) (string, error) {
 	return "", nil
+}
+func (n *NoopIngester) CancelIngest() error {
+	return nil
 }
 
 // Make an Updater that does nothing

--- a/workerapi/server/server_test.go
+++ b/workerapi/server/server_test.go
@@ -260,6 +260,9 @@ func (pdb *pausingDB) Update() error {
 func (pdb *pausingDB) UpdateInterval() time.Duration {
 	return time.Millisecond * 100
 }
+func (pdb *pausingDB) Cancel() error {
+	return nil
+}
 
 type erroringOutputCreator struct{}
 


### PR DESCRIPTION
We needed a way to cleanup stuck fs_util operations that happen as underlying calls during Checkout/Ingest for Bazel tasks, as these were left running previously. Add a Cancel interface and implement in BzFiler (in bzCommand). Run fs_util via an OsExecer so that we can abort it on Cancel().