### PR TITLE
make install all binaries target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ format:
 vet:
 	go vet ./...
 
+install:
+	go install ./binaries/...
+
 ############## dependencies
 
 # tool dependencies for developer workflows only (regenerating test mocks, bindata, thrift or proto code)
@@ -78,23 +81,20 @@ test: test-unit-property-integration coverage
 
 ############## standalone binary & integration tests
 
-swarmtest:
+swarmtest: install
 	# Setup a local schedule against local workers (--strategy local.local)
 	# Then run (with go run) scootapi run_smoke_test with 10 jobs, wait 1m
 	# We build the binaries becuase 'go run' won't consistently pass signals to our program.
-	go install ./binaries/...
 	$(FIRSTGOPATH)/bin/setup-cloud-scoot --strategy local.local run scootapi run_smoke_test --num_jobs 10 --timeout 1m $(TRAVIS_FILTER)
 
-recoverytest:
+recoverytest: install
 	# Some overlap with swarmtest but focuses on sagalog recovery vs worker/checkout correctness.
 	# We build the binaries becuase 'go run' won't consistently pass signals to our program.
 	# Ignore output here to reduce travis log size. Swarmtest is more important and that still logs.
-	go install ./binaries/...
 	$(FIRSTGOPATH)/bin/recoverytest &>/dev/null
 
-integrationtest:
+integrationtest: install
 	# Integration test with some overlap with other standalone tests, but utilizes client binaries
-	go install ./binaries/...
 	$(FIRSTGOPATH)/bin/scoot-integration &>/dev/null
 	$(FIRSTGOPATH)/bin/bazel-integration &>/dev/null
 


### PR DESCRIPTION
Convenient `make install` target alias to install binaries. Particularly useful if this repo is on your gopath; lets Makefile export GO111MODULE=on for you.