### PR TITLE
Rcouto/offline worker panic

### DIFF
--- a/binaries/scoot-integration/main.go
+++ b/binaries/scoot-integration/main.go
@@ -67,7 +67,6 @@ func main() {
 
 	var jsonStatusBytes []byte
 	status := scoot.JobStatus{}
-
 	for status.Status != scoot.Status_COMPLETED {
 		select {
 		case <-timeout:
@@ -87,6 +86,42 @@ func main() {
 			time.Sleep(1 * time.Second)
 		}
 	}
+
+	_, err = offlineWorker(gopath, "localhost:10101")
+	if err != nil {
+		testhelpers.KillAndExit1(cluster1Cmds, err)
+	}
+	jobIDs, err := runXJobs(gopath, snapshotID, 10)
+	if err != nil {
+		testhelpers.KillAndExit1(cluster1Cmds, err)
+	}
+	jobIDToStatus := make(map[string]scoot.JobStatus)
+	for _, jobID := range jobIDs {
+		jobIDToStatus[jobID] = scoot.JobStatus{}
+	}
+	for jobID, status := range jobIDToStatus {
+		timeout = time.After(10 * time.Second)
+		for status.Status != scoot.Status_COMPLETED {
+			select {
+			case <-timeout:
+				testhelpers.KillAndExit1(cluster1Cmds, fmt.Errorf("Timed out while waiting for job to complete"))
+			default:
+				jsonStatusBytes, err = getStatus(gopath, jobID)
+				if err != nil {
+					testhelpers.KillAndExit1(cluster1Cmds, err)
+				}
+				if err = json.Unmarshal(jsonStatusBytes, &status); err != nil {
+					testhelpers.KillAndExit1(cluster1Cmds, err)
+				}
+				log.Infof("Status: %v", status)
+				if status.Status == scoot.Status_COMPLETED {
+					break
+				}
+				time.Sleep(1 * time.Second)
+			}
+		}
+	}
+
 	cluster1Cmds.Kill()
 }
 
@@ -103,6 +138,23 @@ func runJob(gopath, snapshotID string) ([]byte, error) {
 	return exec.Command(gopath+"/bin/scootapi", "run_job", "sleep", "1", "--snapshot_id", snapshotID).Output()
 }
 
+func runXJobs(gopath, snapshotID string, x int) ([]string, error) {
+	jobIDs := []string{}
+	for i := 0; i < x; i++ {
+		jobBytes, err := runJob(gopath, snapshotID)
+		if err != nil {
+			return nil, err
+		}
+		jobID := strings.TrimSpace(string(jobBytes))
+		jobIDs = append(jobIDs, jobID)
+	}
+	return jobIDs, nil
+}
+
 func getStatus(gopath, jobID string) ([]byte, error) {
 	return exec.Command(gopath+"/bin/scootapi", "get_job_status", jobID, "--json").Output()
+}
+
+func offlineWorker(gopath, workerID string) ([]byte, error) {
+	return exec.Command(gopath+"/bin/scootapi", "offline_worker", workerID).Output()
 }

--- a/binaries/scoot-integration/main.go
+++ b/binaries/scoot-integration/main.go
@@ -87,8 +87,9 @@ func main() {
 		}
 	}
 
-	_, err = offlineWorker(gopath, "localhost:10101")
+	_, err = offlineWorker(gopath, fmt.Sprintf("localhost:%d", scootapi.WorkerPorts+1))
 	if err != nil {
+		log.Error(err)
 		testhelpers.KillAndExit1(cluster1Cmds, err)
 	}
 	jobIDs, err := runXJobs(gopath, snapshotID, 10)
@@ -96,6 +97,41 @@ func main() {
 		testhelpers.KillAndExit1(cluster1Cmds, err)
 	}
 	jobIDToStatus := make(map[string]scoot.JobStatus)
+	for _, jobID := range jobIDs {
+		jobIDToStatus[jobID] = scoot.JobStatus{}
+	}
+	for jobID, status := range jobIDToStatus {
+		timeout = time.After(10 * time.Second)
+		for status.Status != scoot.Status_COMPLETED {
+			select {
+			case <-timeout:
+				testhelpers.KillAndExit1(cluster1Cmds, fmt.Errorf("Timed out while waiting for job to complete"))
+			default:
+				jsonStatusBytes, err = getStatus(gopath, jobID)
+				if err != nil {
+					testhelpers.KillAndExit1(cluster1Cmds, err)
+				}
+				if err = json.Unmarshal(jsonStatusBytes, &status); err != nil {
+					testhelpers.KillAndExit1(cluster1Cmds, err)
+				}
+				log.Infof("Status: %v", status)
+				if status.Status == scoot.Status_COMPLETED {
+					break
+				}
+				time.Sleep(1 * time.Second)
+			}
+		}
+	}
+
+	_, err = reinstateWorker(gopath, fmt.Sprintf("localhost:%d", scootapi.WorkerPorts+1))
+	if err != nil {
+		testhelpers.KillAndExit1(cluster1Cmds, err)
+	}
+	jobIDs, err = runXJobs(gopath, snapshotID, 10)
+	if err != nil {
+		testhelpers.KillAndExit1(cluster1Cmds, err)
+	}
+	jobIDToStatus = make(map[string]scoot.JobStatus)
 	for _, jobID := range jobIDs {
 		jobIDToStatus[jobID] = scoot.JobStatus{}
 	}
@@ -157,4 +193,8 @@ func getStatus(gopath, jobID string) ([]byte, error) {
 
 func offlineWorker(gopath, workerID string) ([]byte, error) {
 	return exec.Command(gopath+"/bin/scootapi", "offline_worker", workerID).Output()
+}
+
+func reinstateWorker(gopath, workerID string) ([]byte, error) {
+	return exec.Command(gopath+"/bin/scootapi", "reinstate_worker", workerID).Output()
 }

--- a/sched/scheduler/cluster_state.go
+++ b/sched/scheduler/cluster_state.go
@@ -38,10 +38,8 @@ type clusterState struct {
 }
 
 func (c *clusterState) isOfflined(ns *nodeState) bool {
-	for _, v := range c.offlinedNodes {
-		if v == ns {
-			return true
-		}
+	if _, ok := c.offlinedNodes[ns.node.Id()]; ok {
+		return true
 	}
 	return false
 }

--- a/sched/scheduler/cluster_state.go
+++ b/sched/scheduler/cluster_state.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -35,6 +36,15 @@ type clusterState struct {
 	readyFn          ReadyFn                       // If provided, new nodes will be suspended until this returns true.
 	numRunning       int                           // Number of running nodes. running + free + suspended ~= allNodes (may lag)
 	stats            stats.StatsReceiver           // for collecting stats about node availability
+}
+
+func (c *clusterState) isOfflined(ns *nodeState) bool {
+	for _, v := range c.offlinedNodes {
+		if reflect.DeepEqual(v, ns) {
+			return true
+		}
+	}
+	return false
 }
 
 type nodeGroup struct {

--- a/sched/scheduler/cluster_state.go
+++ b/sched/scheduler/cluster_state.go
@@ -2,7 +2,6 @@ package scheduler
 
 import (
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -40,7 +39,7 @@ type clusterState struct {
 
 func (c *clusterState) isOfflined(ns *nodeState) bool {
 	for _, v := range c.offlinedNodes {
-		if reflect.DeepEqual(v, ns) {
+		if v == ns {
 			return true
 		}
 	}

--- a/sched/scheduler/task_scheduler.go
+++ b/sched/scheduler/task_scheduler.go
@@ -278,7 +278,7 @@ func assign(
 		for _, snapId := range append([]string{task.Def.SnapshotID}, snapIds...) {
 			if groups, ok := nodeGroups[snapId]; ok {
 				for _, ns := range groups.idle {
-					if ns.suspended() {
+					if ns.suspended() || cs.isOfflined(ns) {
 						continue
 					}
 					snapshotId = snapId


### PR DESCRIPTION
Problem

Offlined workers can still have tasks assigned to them, resulting in a panic when the scheduler attempts to access their ID in the active nodes map

Solution

Don't assign to offlined nodes

Result

The OfflineWorker API will be usable, and won't result in scheduler panics.