### PR TITLE
Use temporary repos for bundlestore view server downloads

### DIFF
--- a/snapshot/git/gitdb/backends.go
+++ b/snapshot/git/gitdb/backends.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/twitter/scoot/os/temp"
 	snap "github.com/twitter/scoot/snapshot"
+	"github.com/twitter/scoot/snapshot/git/repo"
 )
 
 // backend allows getting a snapshot for an ID, which can then be used to download the ID
@@ -27,6 +29,9 @@ type snapshot interface {
 	Kind() SnapshotKind
 	SHA() string
 	Download(db *DB) error
+
+	// Download into a preexisting TempDir, resulting in a new Repository at that location
+	DownloadTempRepo(db *DB, tmp *temp.TempDir) (*repo.Repository, error)
 }
 
 // parseID parses ID into a snapshot

--- a/snapshot/git/gitdb/bundlestore.go
+++ b/snapshot/git/gitdb/bundlestore.go
@@ -135,6 +135,7 @@ func (b *bundlestoreBackend) uploadLocalSnapshot(s *localSnapshot, db *DB) (sn s
 		return nil, err
 	}
 
+	// TODO clean up
 	d, err := db.tmp.TempDir("bundle-")
 	if err != nil {
 		return nil, err

--- a/snapshot/git/gitdb/bundlestore.go
+++ b/snapshot/git/gitdb/bundlestore.go
@@ -11,7 +11,9 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/twitter/scoot/os/temp"
 	snap "github.com/twitter/scoot/snapshot"
+	"github.com/twitter/scoot/snapshot/git/repo"
 	"github.com/twitter/scoot/snapshot/store"
 )
 
@@ -135,7 +137,6 @@ func (b *bundlestoreBackend) uploadLocalSnapshot(s *localSnapshot, db *DB) (sn s
 		return nil, err
 	}
 
-	// TODO clean up
 	d, err := db.tmp.TempDir("bundle-")
 	if err != nil {
 		return nil, err
@@ -200,9 +201,12 @@ func (s *bundlestoreSnapshot) Download(db *DB) error {
 		return nil
 	}
 
-	// TODO(dbentley): keep stats about bundlestore downloading
-	// TODO(dbentley): keep stats about how long it takes to unbundle
-	filename, err := s.downloadBundle(db)
+	dlDir, filename, err := s.downloadBundle(db)
+	if dlDir != "" {
+		defer func() {
+			os.RemoveAll(dlDir)
+		}()
+	}
 	if err != nil {
 		log.Info("Unable to download bundle: ", err)
 		return err
@@ -255,29 +259,59 @@ func (s *bundlestoreSnapshot) Download(db *DB) error {
 	return db.shaPresent(s.sha)
 }
 
-func (s *bundlestoreSnapshot) downloadBundle(db *DB) (filename string, err error) {
+// TODO separate the use cases that need git/repo/stream semantics from things that can be passed
+// around as binary bundles, and simplify the use cases accordingly
+func (s *bundlestoreSnapshot) DownloadTempRepo(db *DB, tmp *temp.TempDir) (*repo.Repository, error) {
+	log.Infof("Downloading sha: %s", s.SHA())
+
+	tmpRepoIniter := &TmpRepoIniter{tmp: db.tmp}
+	tmpRepo, err := tmpRepoIniter.Init()
+	if err != nil {
+		return nil, err
+	}
+
+	dlDir, filename, err := s.downloadBundle(db)
+	if dlDir != "" {
+		defer func() {
+			os.RemoveAll(dlDir)
+		}()
+	}
+	if err != nil {
+		log.Info("Unable to download bundle: ", err)
+		return tmpRepo, err
+	}
+
+	if _, err = tmpRepo.Run("bundle", "unbundle", filename); err != nil {
+		return tmpRepo, err
+	}
+	log.Infof("Unbundling got the sha: %s, returning from DownloadTempRepo()", s.SHA())
+
+	return tmpRepo, tmpRepo.ShaPresent(s.sha)
+}
+
+func (s *bundlestoreSnapshot) downloadBundle(db *DB) (string, string, error) {
 	d, err := db.tmp.TempDir("bundle-")
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	bundleName := makeBundleName(s.bundleKey)
 	bundleFilename := path.Join(d.Dir, bundleName)
 	f, err := os.Create(bundleFilename)
 	if err != nil {
-		return "", err
+		return d.Dir, "", err
 	}
 	defer f.Close()
 
 	r, err := db.bundles.cfg.Store.OpenForRead(bundleName)
 	if err != nil {
-		return "", err
+		return d.Dir, "", err
 	}
 	defer r.Close()
 	if _, err := io.Copy(f, r); err != nil {
-		return "", err
+		return d.Dir, "", err
 	}
 
-	return f.Name(), nil
+	return d.Dir, f.Name(), nil
 }
 
 func makeBundleName(key string) string {

--- a/snapshot/git/gitdb/bundlestore.go
+++ b/snapshot/git/gitdb/bundlestore.go
@@ -203,9 +203,7 @@ func (s *bundlestoreSnapshot) Download(db *DB) error {
 
 	dlDir, filename, err := s.downloadBundle(db)
 	if dlDir != "" {
-		defer func() {
-			os.RemoveAll(dlDir)
-		}()
+		defer os.RemoveAll(dlDir)
 	}
 	if err != nil {
 		log.Info("Unable to download bundle: ", err)
@@ -272,9 +270,7 @@ func (s *bundlestoreSnapshot) DownloadTempRepo(db *DB, tmp *temp.TempDir) (*repo
 
 	dlDir, filename, err := s.downloadBundle(db)
 	if dlDir != "" {
-		defer func() {
-			os.RemoveAll(dlDir)
-		}()
+		defer os.RemoveAll(dlDir)
 	}
 	if err != nil {
 		log.Info("Unable to download bundle: ", err)

--- a/snapshot/git/gitdb/checkout.go
+++ b/snapshot/git/gitdb/checkout.go
@@ -11,8 +11,8 @@ import (
 	"github.com/twitter/scoot/snapshot/git/repo"
 )
 
-// NOTE we assume in practice this only gets used where downloading and reading
-// the file to a tempdir, which is then deleted, is acceptable
+// NOTE we assume in practice this only gets used where we are downloading and reading
+// the file to a tempdir, and any underlying file/snapshot is deleted
 func (db *DB) readFileAll(id snap.ID, path string) (string, error) {
 	v, err := db.parseID(id)
 	if err != nil {

--- a/snapshot/git/gitdb/checkout.go
+++ b/snapshot/git/gitdb/checkout.go
@@ -11,6 +11,7 @@ import (
 	"github.com/twitter/scoot/snapshot/git/repo"
 )
 
+// TODO cleanup from this entry point only
 func (db *DB) readFileAll(id snap.ID, path string) (string, error) {
 	v, err := db.parseID(id)
 	if err != nil {

--- a/snapshot/git/gitdb/create.go
+++ b/snapshot/git/gitdb/create.go
@@ -55,7 +55,7 @@ func (db *DB) ingestGitCommit(ingestRepo *repo.Repository, commitish string) (sn
 		return nil, fmt.Errorf("not a valid commit: %s, %v", commitish, err)
 	}
 
-	if err := db.shaPresent(sha); err == nil {
+	if err := db.dataRepo.ShaPresent(sha); err == nil {
 		return &localSnapshot{sha: sha, kind: KindGitCommitSnapshot}, nil
 	}
 
@@ -96,6 +96,5 @@ func (db *DB) ingestGitWorkingDir(ingestRepo *repo.Repository) (snapshot, error)
 }
 
 func (db *DB) shaPresent(sha string) error {
-	_, err := db.dataRepo.Run("rev-parse", "--verify", sha+"^{object}")
-	return err
+	return db.dataRepo.ShaPresent(sha)
 }

--- a/snapshot/git/gitdb/db.go
+++ b/snapshot/git/gitdb/db.go
@@ -12,6 +12,8 @@ import (
 	"github.com/twitter/scoot/snapshot/store"
 )
 
+// TODO The interfaces and functionality here should be refactored to only use git when necessary
+
 // SnapshotKind describes the kind of a Snapshot: is it an FSSnapshot or a GitCommitSnapshot
 // kind instead of type because type is a keyword
 type SnapshotKind string

--- a/snapshot/git/gitdb/db.go
+++ b/snapshot/git/gitdb/db.go
@@ -12,7 +12,9 @@ import (
 	"github.com/twitter/scoot/snapshot/store"
 )
 
-// TODO The interfaces and functionality here should be refactored to only use git when necessary
+// TODO The interfaces and functionality here should be refactored to only use git when necessary.
+// Many operations relying on git are more inefficient than they need to be:
+// we could be using memory buffers/streams instead of using git cmds on disk to transform data.
 
 // SnapshotKind describes the kind of a Snapshot: is it an FSSnapshot or a GitCommitSnapshot
 // kind instead of type because type is a keyword

--- a/snapshot/git/gitdb/db_test.go
+++ b/snapshot/git/gitdb/db_test.go
@@ -483,6 +483,14 @@ func TestBundlestore(t *testing.T) {
 	if err := assertSnapshotContents(consumerDB, id, "stdout.txt", "stdout"); err != nil {
 		t.Fatal(err)
 	}
+
+	data, err := consumerDB.ReadFileAll(id, "stdout.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "stdout" {
+		t.Fatalf("Read data from stdout.txt: %q, wanted: %q", string(data), "stdout")
+	}
 }
 
 type dbFixture struct {

--- a/snapshot/git/gitdb/git_tags.go
+++ b/snapshot/git/gitdb/git_tags.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/twitter/scoot/os/temp"
 	snap "github.com/twitter/scoot/snapshot"
+	"github.com/twitter/scoot/snapshot/git/repo"
 )
 
 // TagsConfig specifies how GitDB should store Snapshots as tags in another git repo
@@ -97,6 +99,10 @@ func (s *tagsSnapshot) Download(db *DB) error {
 	}
 
 	return db.shaPresent(s.SHA())
+}
+
+func (s *tagsSnapshot) DownloadTempRepo(db *DB, tmp *temp.TempDir) (*repo.Repository, error) {
+	return nil, errors.New("DownloadTempRepo unimplemented in tagsSnapshot")
 }
 
 // we store tags as <prefix>/<sha>, e.g. reserved_scoot/1cdbb0e2c889a2e301589cc349615c2c1545f641

--- a/snapshot/git/gitdb/local_data.go
+++ b/snapshot/git/gitdb/local_data.go
@@ -1,9 +1,12 @@
 package gitdb
 
 import (
+	"errors"
 	"fmt"
 
+	"github.com/twitter/scoot/os/temp"
 	snap "github.com/twitter/scoot/snapshot"
+	"github.com/twitter/scoot/snapshot/git/repo"
 )
 
 const localIDText = "local"
@@ -38,4 +41,8 @@ func (s *localSnapshot) SHA() string        { return s.sha }
 func (s *localSnapshot) Download(db *DB) error {
 	// a localSnapshot is either present already or we have no way to download it
 	return db.shaPresent(s.SHA())
+}
+
+func (s *localSnapshot) DownloadTempRepo(db *DB, tmp *temp.TempDir) (*repo.Repository, error) {
+	return nil, errors.New("DownloadTempRepo unimplemented in localSnapshot")
 }

--- a/snapshot/git/gitdb/stream.go
+++ b/snapshot/git/gitdb/stream.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 
 	"github.com/twitter/scoot/common/stats"
+	"github.com/twitter/scoot/os/temp"
 	snap "github.com/twitter/scoot/snapshot"
+	"github.com/twitter/scoot/snapshot/git/repo"
 )
 
 // A Stream is a sequence of GitCommitSnapshots that updates.
@@ -84,6 +86,10 @@ func (s *streamSnapshot) Download(db *DB) error {
 	}
 
 	return db.shaPresent(s.SHA())
+}
+
+func (s *streamSnapshot) DownloadTempRepo(db *DB, tmp *temp.TempDir) (*repo.Repository, error) {
+	return nil, errors.New("DownloadTempRepo unimplemented in streamSnapshot")
 }
 
 // updateStream updates the named stream

--- a/snapshot/git/repo/repo.go
+++ b/snapshot/git/repo/repo.go
@@ -102,6 +102,12 @@ func (r *Repository) RunExtraEnvSha(extraEnv []string, args ...string) (string, 
 	return validateSha(out)
 }
 
+// Returns nil if the Repository contains a given sha, or an error if not
+func (r *Repository) ShaPresent(sha string) error {
+	_, err := r.Run("rev-parse", "--verify", sha+"^{object}")
+	return err
+}
+
 // validateSha trims and validates sha as a git sha, returning the valid sha xor an error
 func validateSha(sha string) (string, error) {
 	if len(sha) == 40 || len(sha) == 41 && sha[40] == '\n' {


### PR DESCRIPTION
Requests to an apiserver's view endpoint are made with git-based objects. For example, to view a task std* log from the view server, the apiserver would fetch the underlying binary data from an underlying store, treat that as a git bundle and unbundle it into the apiserver's "blank" git repo, and then ingest & serve the requested file.

This "blank" git repo (an instance of snapshot/git/gitdb) is never pruned. Over time, as many bundles are unbundled into this repo, operations within it slow to a crawl. Instead of pruning this repo, we create a new code path (DownloadTempRepo) that creates these objects in fleeting blank git repos that are wiped entirely after the request is served.

There is no advantage to treating these types of requests as git bundles; if anything it's slowing things down and makes these requests difficult to understand. Refactoring this out will be time consuming, so some todos have been added to that effect and we opt to only fix the pruning issue here.