### PR TITLE
snapshot/store - add Length to store Resource and populate

### DIFF
--- a/bazel/cas/service_test.go
+++ b/bazel/cas/service_test.go
@@ -59,7 +59,7 @@ func TestFindMissingBlobs(t *testing.T) {
 
 	resourceName := bazel.DigestStoreName(dExists)
 	buf := ioutil.NopCloser(bytes.NewReader([]byte("")))
-	err := f.Write(resourceName, store.NewResource(buf, nil))
+	err := f.Write(resourceName, store.NewResource(buf, 0, nil))
 	if err != nil {
 		t.Fatalf("Failed to write into FakeStore: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestRead(t *testing.T) {
 	d := &remoteexecution.Digest{Hash: testHash1, SizeBytes: testSize1}
 	resourceName := bazel.DigestStoreName(d)
 	buf := ioutil.NopCloser(bytes.NewReader(testData1))
-	err := f.Write(resourceName, store.NewResource(buf, nil))
+	err := f.Write(resourceName, store.NewResource(buf, testSize1, nil))
 	if err != nil {
 		t.Fatalf("Failed to write into FakeStore: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestWriteExisting(t *testing.T) {
 
 	resourceName := bazel.DigestStoreName(d)
 	buf := ioutil.NopCloser(bytes.NewReader(testData1))
-	err := f.Write(resourceName, store.NewResource(buf, nil))
+	err := f.Write(resourceName, store.NewResource(buf, testSize1, nil))
 	if err != nil {
 		t.Fatalf("Failed to write into FakeStore: %v", err)
 	}
@@ -397,7 +397,7 @@ func TestBatchReadBlobs(t *testing.T) {
 		d := &remoteexecution.Digest{Hash: writeHashes[i], SizeBytes: writeSizes[i]}
 		resourceName := bazel.DigestStoreName(d)
 		buf := ioutil.NopCloser(bytes.NewReader(writeData[i]))
-		err := f.Write(resourceName, store.NewResource(buf, nil))
+		err := f.Write(resourceName, store.NewResource(buf, writeSizes[i], nil))
 		if err != nil {
 			t.Fatalf("Failed to write into FakeStore: %v", err)
 		}
@@ -499,7 +499,7 @@ func TestGetActionResult(t *testing.T) {
 		t.Fatalf("Failed to create cache result adress: %v", err)
 	}
 	buf := ioutil.NopCloser(bytes.NewReader(arAsBytes))
-	err = f.Write(address.storeName, store.NewResource(buf, nil))
+	err = f.Write(address.storeName, store.NewResource(buf, int64(len(arAsBytes)), nil))
 	if err != nil {
 		t.Fatalf("Failed to write into FakeStore: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/twitter/go-bindata v0.0.0-20180208183117-2fa2cba09795 // indirect
-	github.com/twitter/groupcache v0.0.0-20190830224244-7699c26b8c0c
+	github.com/twitter/groupcache v0.0.0-20190909015146-10d21707d5fe
 	golang.org/x/exp v0.0.0-20190121172915-509febef88a4 // indirect
 	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7

--- a/go.mod
+++ b/go.mod
@@ -34,5 +34,3 @@ require (
 	google.golang.org/grpc v1.14.0
 	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )
-
-replace github.com/twitter/groupcache => ../groupcache

--- a/go.mod
+++ b/go.mod
@@ -34,3 +34,5 @@ require (
 	google.golang.org/grpc v1.14.0
 	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )
+
+replace github.com/twitter/groupcache => ../groupcache

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,7 @@ github.com/twitter/groupcache v0.0.0-20190830195751-11158c6be16d h1:jb3jKhSKeHt9
 github.com/twitter/groupcache v0.0.0-20190830195751-11158c6be16d/go.mod h1:F3VyMCQItbfWsYao7dIdhp2t4hdXRuJIIC7RWWmyijM=
 github.com/twitter/groupcache v0.0.0-20190830224244-7699c26b8c0c h1:xBiot0J/CGFtU93ACvuh6ihwmdEb81tqfqUbJS5O/mQ=
 github.com/twitter/groupcache v0.0.0-20190830224244-7699c26b8c0c/go.mod h1:fcAzz9dBuUo1tHcNFsXFI7dRwSAAKsjCraVFeByrhUc=
+github.com/twitter/groupcache v0.0.0-20190909015146-10d21707d5fe/go.mod h1:fcAzz9dBuUo1tHcNFsXFI7dRwSAAKsjCraVFeByrhUc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8 h1:3SVOIvH7Ae1KRYyQWRjXWJEA9sS/c/pjvH++55Gr648=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77 h1:ESFSdwYZvkeru3RtdrYueztKhOBCSAAzS4Gf+k0tEow=

--- a/snapshot/bundlestore/http_server.go
+++ b/snapshot/bundlestore/http_server.go
@@ -69,7 +69,7 @@ func (s *httpServer) HandleUpload(w http.ResponseWriter, req *http.Request) {
 		}
 		break
 	}
-	if err := s.storeConfig.Store.Write(bundleName, store.NewResource(bundleData, ttl)); err != nil {
+	if err := s.storeConfig.Store.Write(bundleName, store.NewResource(bundleData, req.ContentLength, ttl)); err != nil {
 		log.Infof("Write err: %v --> StatusInternalServerError (from %v)", err, req.RemoteAddr)
 		http.Error(w, fmt.Sprintf("Error writing Bundle: %s", err), http.StatusInternalServerError)
 		s.storeConfig.Stat.Counter(stats.BundlestoreUploadErrCounter).Inc(1)

--- a/snapshot/git/gitdb/bundlestore.go
+++ b/snapshot/git/gitdb/bundlestore.go
@@ -330,11 +330,11 @@ func (b *bundlestoreBackend) uploadFile(filePath string, ttl *store.TTLValue) (s
 	if err != nil {
 		return "", err
 	}
+	defer f.Close()
 	fi, err := f.Stat()
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
 
 	name := path.Base(filePath)
 	if name == "." || name == "/" {

--- a/snapshot/git/gitdb/bundlestore.go
+++ b/snapshot/git/gitdb/bundlestore.go
@@ -330,6 +330,10 @@ func (b *bundlestoreBackend) uploadFile(filePath string, ttl *store.TTLValue) (s
 	if err != nil {
 		return "", err
 	}
+	fi, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
 	defer f.Close()
 
 	name := path.Base(filePath)
@@ -337,7 +341,7 @@ func (b *bundlestoreBackend) uploadFile(filePath string, ttl *store.TTLValue) (s
 		return "", fmt.Errorf("Invalid path %v, base parsed to %v", filePath, name)
 	}
 
-	resource := store.NewResource(f, ttl)
+	resource := store.NewResource(f, fi.Size(), ttl)
 	if err := b.cfg.Store.Write(name, resource); err != nil {
 		return "", err
 	}

--- a/snapshot/store/fake_store.go
+++ b/snapshot/store/fake_store.go
@@ -32,7 +32,7 @@ func (f *FakeStore) OpenForRead(name string) (*Resource, error) {
 	}
 	rc := ioutil.NopCloser(bytes.NewBuffer(b))
 
-	return NewResource(rc, f.TTL), nil
+	return NewResource(rc, int64(len(b)), f.TTL), nil
 }
 
 func (f *FakeStore) Root() string { return "" }

--- a/snapshot/store/file_store.go
+++ b/snapshot/store/file_store.go
@@ -34,7 +34,14 @@ type FileStore struct {
 func (s *FileStore) OpenForRead(name string) (*Resource, error) {
 	bundlePath := filepath.Join(s.bundleDir, name)
 	r, err := os.Open(bundlePath)
-	return NewResource(r, nil), err
+	if err != nil {
+		return nil, err
+	}
+	fi, err := r.Stat()
+	if err != nil {
+		return nil, err
+	}
+	return NewResource(r, fi.Size(), nil), err
 }
 
 func (s *FileStore) Exists(name string) (bool, error) {
@@ -70,6 +77,11 @@ func (s *FileStore) Write(name string, resource *Resource) error {
 	if _, err := io.Copy(f, resource); err != nil {
 		return err
 	}
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	resource.Length = fi.Size()
 	return nil
 }
 

--- a/snapshot/store/groupcache_store.go
+++ b/snapshot/store/groupcache_store.go
@@ -136,10 +136,13 @@ func (s *groupcacheStore) OpenForRead(name string) (*Resource, error) {
 	if err != nil {
 		return nil, err
 	}
-	ttlv := TTLValue{TTL: *ttl, TTLKey: s.ttlConfig.TTLKey}
+	var ttlv *TTLValue = nil
+	if ttl != nil {
+		ttlv = &TTLValue{TTL: *ttl, TTLKey: s.ttlConfig.TTLKey}
+	}
 	rc := ioutil.NopCloser(bytes.NewReader(data))
 	s.stat.Counter(stats.GroupcacheReadOkCounter).Inc(1)
-	return NewResource(rc, int64(len(data)), &ttlv), nil
+	return NewResource(rc, int64(len(data)), ttlv), nil
 }
 
 func (s *groupcacheStore) Exists(name string) (bool, error) {

--- a/snapshot/store/http_store.go
+++ b/snapshot/store/http_store.go
@@ -88,7 +88,7 @@ func (s *httpStore) openForRead(name string, existCheck bool) (*Resource, error)
 	if resp.StatusCode == http.StatusOK {
 		log.Infof("%s result %s %v", label, uri, resp.StatusCode)
 		ttlv := s.getTTLValue(resp)
-		return NewResource(resp.Body, ttlv), nil
+		return NewResource(resp.Body, resp.ContentLength, ttlv), nil
 	}
 	log.Infof("%s response status error: %s %v", label, uri, resp.Status)
 
@@ -134,6 +134,7 @@ func (s *httpStore) Write(name string, resource *Resource) error {
 		if err != nil {
 			return nil, err
 		}
+		req.ContentLength = resource.Length
 		req.Header.Set("Content-Type", "text/plain")
 		ttl := resource.TTLValue
 		if ttl == nil {

--- a/snapshot/store/store.go
+++ b/snapshot/store/store.go
@@ -51,15 +51,18 @@ func GetDurationTTL(t *TTLValue) time.Duration {
 	return d
 }
 
-// Resource is io readable as well as ttl aware.
+// Resource encapsulates a Store resource and embeds an io.ReadCloser around the data
+// Length: length in bytes of data to be read or written
+// TTLValue: TTL value for the resource, or nil if not supporting TTL
 type Resource struct {
 	io.ReadCloser
+	Length   int64
 	TTLValue *TTLValue
 }
 
 // NewResource constructs a new resource.
-func NewResource(rc io.ReadCloser, TTLValue *TTLValue) *Resource {
-	return &Resource{ReadCloser: rc, TTLValue: TTLValue}
+func NewResource(rc io.ReadCloser, l int64, ttlv *TTLValue) *Resource {
+	return &Resource{ReadCloser: rc, Length: l, TTLValue: ttlv}
 }
 
 // Read-only operations on store, limited for now to a couple essential functions.


### PR DESCRIPTION
Explicitly set ContentLength in http_store.

The previous change in #445 altered the Store.Write API to use a Resource with an embedded io.ReadCloser. This had the side effect of obscuring the length of the data in the http store Write implementation, which only worked on more transparent Reader values. Add an explicit Length to Resources.