### PR TITLE
adding noop store

### DIFF
--- a/snapshot/store/noop_store.go
+++ b/snapshot/store/noop_store.go
@@ -1,0 +1,28 @@
+package store
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Implements Store with no actions being taken on any methods.
+type NoopStore struct {
+}
+
+func (f *NoopStore) Exists(name string) (bool, error) {
+	log.Infof("Noop Exists returning false")
+	return false, nil
+}
+
+func (f *NoopStore) OpenForRead(name string) (*Resource, error) {
+	log.Infof("Noop OpenForRead returning nil and noop retrieve error.")
+	return nil, fmt.Errorf("Retreiving %s from Noop store. (No values stored in Noop store.)", name)
+}
+
+func (f *NoopStore) Root() string { return "" }
+
+func (f *NoopStore) Write(name string, resource *Resource) error {
+	log.Infof("Noop Write returning nil.")
+	return nil
+}


### PR DESCRIPTION
Problem

We want an apiserver that only saves the content it's managing in memory (does not also read/write to a file or some other store).

Solution

Provide a noop store that apiserver can use for it's underlying store.

Result

When an apiserver is configured with noop store as its underlying store, content will only be stored in the apiservers' memory.
