### PR TITLE
Use allocator (limiter) to limit concurrent CAS requests

### DIFF
--- a/bazel/cas/constants.go
+++ b/bazel/cas/constants.go
@@ -28,9 +28,6 @@ const (
 	MaxRequestsBurst           = 250  // allows this many requests in a burst faster than MaxRPS average
 	MaxConcurrentStreams       = 0    // limits concurrent streams _per client_
 
-	// Default total resource capacity for concurrent in-flight requests
-	DefaultConcurrentResourceBytes = int64(1024 * 1024 * 1024)
-
 	unableToAllocMsg = "server failed to reserve resources for request"
 )
 

--- a/bazel/cas/constants.go
+++ b/bazel/cas/constants.go
@@ -21,16 +21,27 @@ const (
 	// ActionCache constants
 	ResultAddressKey = "ActionCacheResult"
 
+	// TODO name default
 	// GRPC Server connection-related setting limits recommended for CAS
 	MaxSimultaneousConnections = 1000 // limits total simultaneous connections via the Listener
 	MaxRequestsPerSecond       = 500  // limits total incoming requests allowed per second
 	MaxRequestsBurst           = 250  // allows this many requests in a burst faster than MaxRPS average
 	MaxConcurrentStreams       = 0    // limits concurrent streams _per client_
+
+	// Default total resource capacity for concurrent in-flight requests
+	DefaultConcurrentResourceBytes = int64(1024 * 1024 * 1024)
+
+	unableToAllocMsg = "server failed to reserve resources for request"
 )
 
-// Resource naming format guidelines
-var ResourceReadFormatStr string = fmt.Sprintf("[<instance-name>/]%s/<hash>/<size>[/filename]", ResourceNameType)
-var ResourceWriteFormatStr string = fmt.Sprintf("[<instance-name>/]%s/<uuid>/%s/<hash>/<size>[/filename]", ResourceNameAction, ResourceNameType)
+var (
+	// Resource naming format guidelines
+	ResourceReadFormatStr  string = fmt.Sprintf("[<instance-name>/]%s/<hash>/<size>[/filename]", ResourceNameType)
+	ResourceWriteFormatStr string = fmt.Sprintf("[<instance-name>/]%s/<uuid>/%s/<hash>/<size>[/filename]", ResourceNameAction, ResourceNameType)
 
-// Default TTL for CAS-based operations
-var DefaultTTL time.Duration = time.Hour * 24 * 7
+	// Default TTL for CAS-based operations
+	DefaultTTL time.Duration = time.Hour * 24 * 7
+
+	// Duration to wait for available concurrent resources before returning an error
+	WaitForResourceDuration time.Duration = time.Second * 10
+)

--- a/bazel/cas/constants.go
+++ b/bazel/cas/constants.go
@@ -17,18 +17,21 @@ const (
 	// NOTE experimental/arbitrary setting. Consider adding a mechanism to set via StoreConfigs
 	// NOTE if service implementation is changed, retest with setting <= 5
 	BatchParallelism = 5
+	// Batch API max combined blobs inlined request size
+	BatchMaxCombinedSize = 10 * 1024 * 1024
 
 	// ActionCache constants
 	ResultAddressKey = "ActionCacheResult"
 
-	// TODO name default
 	// GRPC Server connection-related setting limits recommended for CAS
 	MaxSimultaneousConnections = 1000 // limits total simultaneous connections via the Listener
 	MaxRequestsPerSecond       = 500  // limits total incoming requests allowed per second
 	MaxRequestsBurst           = 250  // allows this many requests in a burst faster than MaxRPS average
 	MaxConcurrentStreams       = 0    // limits concurrent streams _per client_
 
-	unableToAllocMsg = "server failed to reserve resources for request"
+	// Error messages
+	exceedBatchMaxMsg = "batch combined request size exceeds maximum"
+	unableToAllocMsg  = "server failed to reserve resources for request"
 )
 
 var (

--- a/bazel/cas/service.go
+++ b/bazel/cas/service.go
@@ -46,15 +46,15 @@ func MakeCASServer(gc *bazel.GRPCConfig, sc *store.StoreConfig, stat stats.Stats
 		return nil
 	}
 
+	a, err := allocator.NewAbstractAllocator(gc.ConcurrentReqSize)
+	if err != nil {
+		panic(err)
+	}
 	l, err := gc.NewListener()
 	if err != nil {
 		panic(err)
 	}
 	gs := gc.NewGRPCServer()
-	a, err := allocator.NewAbstractAllocator(1048576) //TODO 1MB; configurable size
-	if err != nil {
-		panic(err)
-	}
 	g := casServer{
 		listener:    l,
 		server:      gs,

--- a/bazel/cas/service_test.go
+++ b/bazel/cas/service_test.go
@@ -715,7 +715,7 @@ func readAndCompare(f store.Store, name string, testData []byte) ([]byte, error)
 }
 
 func makeCasFromStore(s store.Store) casServer {
-	a, _ := allocator.NewAbstractAllocator(DefaultConcurrentResourceBytes)
+	a, _ := allocator.NewAbstractAllocator(10 * 1024 * 1024)
 	return casServer{
 		storeConfig: &store.StoreConfig{Store: s},
 		stat:        stats.NilStatsReceiver(),

--- a/bazel/server.go
+++ b/bazel/server.go
@@ -35,6 +35,7 @@ type GRPCConfig struct {
 	BurstLimitPerSec  int    // Maximum per-burst incoming requests per second (within RateLimitPerSec)
 	ConcurrentStreams int    // Maximum concurrent GRPC streams allowed per client
 	MaxConnIdleMins   int    // Maximum time a connection can remain open until the server closes it
+	ConcurrentReqSize int64  // Size of resources used in concurrent requests, in bytes (Internal usage)
 }
 
 // Creates a new net.Listener with the configured address and limits

--- a/binaries/apiserver/main.go
+++ b/binaries/apiserver/main.go
@@ -32,6 +32,7 @@ func main() {
 	configFlag := flag.String("config", "{}", "API Server Config (either a filename like local.local or JSON text")
 	logLevelFlag := flag.String("log_level", "info", "Log everything at this level and above (error|info|debug)")
 	cacheSize := flag.Int64("cache_size", 2*1024*1024*1024, "In-memory bundle cache size in bytes")
+	// TODO add a request buffer size. can probably remove all the grpc tuning flags if that works.
 	grpcConns := flag.Int("max_grpc_conn", cas.MaxSimultaneousConnections, "max grpc listener connections")
 	grpcRate := flag.Int("max_grpc_rps", cas.MaxRequestsPerSecond, "max grpc incoming requests per second")
 	grpcBurst := flag.Int("max_grpc_rps_burst", cas.MaxRequestsBurst, "max grpc incoming requests burst")

--- a/binaries/apiserver/main.go
+++ b/binaries/apiserver/main.go
@@ -32,7 +32,7 @@ func main() {
 	configFlag := flag.String("config", "{}", "API Server Config (either a filename like local.local or JSON text")
 	logLevelFlag := flag.String("log_level", "info", "Log everything at this level and above (error|info|debug)")
 	cacheSize := flag.Int64("cache_size", 2*1024*1024*1024, "In-memory bundle cache size in bytes")
-	// TODO add a request buffer size. can probably remove all the grpc tuning flags if that works.
+	casBufferSize := flag.Int64("cas_buffer_size", 2*1024*1024*1024, "In-memory size of all concurrent CAS requests")
 	grpcConns := flag.Int("max_grpc_conn", cas.MaxSimultaneousConnections, "max grpc listener connections")
 	grpcRate := flag.Int("max_grpc_rps", cas.MaxRequestsPerSecond, "max grpc incoming requests per second")
 	grpcBurst := flag.Int("max_grpc_rps_burst", cas.MaxRequestsBurst, "max grpc incoming requests burst")
@@ -107,6 +107,7 @@ func main() {
 				BurstLimitPerSec:  *grpcBurst,
 				ConcurrentStreams: *grpcStreams,
 				MaxConnIdleMins:   *grpcIdleMins,
+				ConcurrentReqSize: *casBufferSize,
 			}
 		},
 	)

--- a/common/allocator/allocator.go
+++ b/common/allocator/allocator.go
@@ -1,0 +1,103 @@
+// Package allocator provides tools for centralized management
+// of a common resource by multiple clients.
+package allocator
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// AbstractAllocator controls access to an abstract pool of resources of a specified capacity.
+// Abstract in this sense means the resources don't actually represent a physical resource
+// (such as disk, memory, etc), but a means of limiting overall concurrent usage by a set of clients.
+type AbstractAllocator struct {
+	mu        sync.Mutex
+	capacity  int64
+	allocated int64
+}
+
+// NewAbstractAllocator returns a new *AbstractAllocator initialized with a set capacity.
+// Returns an error if capacity is < 0. Typical usage of this allocator:
+//	a := NewAbstractAllocator(1024)
+//	r, err := a.Alloc(64)
+//	// handle err
+//	defer r.Release()
+func NewAbstractAllocator(c int64) (*AbstractAllocator, error) {
+	if c < 0 {
+		return nil, fmt.Errorf("invalid capacity %d < 0", c)
+	}
+	return &AbstractAllocator{capacity: c}, nil
+}
+
+// Alloc returns a resource of an indicated size or an error.
+// If error is nil, a non-nil *AbstractResource is returned, which the client must
+// Release when finished, or a resource leak will result.
+func (a *AbstractAllocator) Alloc(size int64) (*AbstractResource, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if size < 0 {
+		return nil, fmt.Errorf("invalid size %d < 0", size)
+	}
+	if a.allocated+size > a.capacity {
+		return nil, fmt.Errorf(
+			"alloc request: %d exceeds capacity: %d (current allocation: %d)", size, a.capacity, a.allocated)
+	}
+	a.allocated += size
+	return &AbstractResource{size: size, a: a}, nil
+}
+
+// WaitAlloc attempts to perform an Alloc up until any supplied context has been cancelled.
+// WaitAlloc will immediately attempt an Alloc and, if unable, will retry at an unspecified
+// rate until the context has cancelled or the Alloc has completed successfully.
+func (a *AbstractAllocator) WaitAlloc(ctx context.Context, size int64) (*AbstractResource, error) {
+	r, err := a.Alloc(size)
+	if err == nil {
+		return r, nil
+	}
+
+	t := time.NewTicker(250 * time.Millisecond)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			r, err = a.Alloc(size)
+			if err == nil {
+				return r, nil
+			}
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+// Release returns a given resource back to the allocator. Releasing a nil
+// or previously released resource does nothing.
+func (a *AbstractAllocator) release(r *AbstractResource) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if r != nil {
+		a.allocated -= r.size
+		if a.allocated < 0 {
+			a.allocated = 0
+		}
+		// unset the resource to prevent accidental double-releasing
+		r.size = 0
+	}
+}
+
+// AbstractResource represents some amount of resources granted
+// by an AbstractAllocator and held by a client.
+type AbstractResource struct {
+	size int64
+	a    *AbstractAllocator
+}
+
+// Release returns a given resource back to the allocator that created this
+// resource. Releasing a nil or previously released resource does nothing.
+func (r *AbstractResource) Release() {
+	if r != nil && r.a != nil {
+		r.a.release(r)
+	}
+}

--- a/common/allocator/allocator_test.go
+++ b/common/allocator/allocator_test.go
@@ -1,0 +1,96 @@
+package allocator
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestSimpleAllocs(t *testing.T) {
+	_, err := NewAbstractAllocator(-1)
+	if err == nil {
+		t.Fatal("expected error to allocate with negative capacity")
+	}
+
+	a, err := NewAbstractAllocator(42069)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// normal allocation
+	r1, err := a.Alloc(42068)
+	if err != nil {
+		t.Fatalf("error from Alloc: %s", err)
+	}
+
+	// try to allocate beyond capacity
+	_, err = a.Alloc(99999)
+	if err == nil {
+		t.Fatal("expected to fail to allocate beyond capacity")
+	}
+
+	// release and verify resources available
+	r1.Release()
+	r2, err := a.Alloc(10000)
+	if err != nil {
+		t.Fatalf("Error from Alloc: %s", err)
+	}
+
+	// verify expected allocated amount
+	if a.allocated != 10000 {
+		t.Fatalf("allocated amount doesn't match, got: %d, want: %d", a.allocated, 10000)
+	}
+
+	// verify double release does nothing
+	r1.Release()
+	if a.allocated != 10000 {
+		t.Fatalf("allocated amount doesn't match, got: %d, want: %d", a.allocated, 10000)
+	}
+
+	// verify we can't release below 0
+	r2.Release()
+	r3 := &AbstractResource{size: 99999999, a: a}
+	r3.Release()
+	if a.allocated != 0 {
+		t.Fatalf("allocated amount doesn't match, got: %d, want: %d", a.allocated, 0)
+	}
+
+	// negative allocation
+	_, err = a.Alloc(-1)
+	if err == nil {
+		t.Fatal("expected error to allocate negative quantity")
+	}
+}
+
+func TestWaitAllocs(t *testing.T) {
+	a, err := NewAbstractAllocator(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify behavior as regular alloc
+	ctx := context.Background()
+	r1, err := a.WaitAlloc(ctx, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel1()
+	r2, err := a.WaitAlloc(ctx1, 10)
+	if err == nil {
+		t.Fatal("expected to fail WaitAlloc with short deadline")
+	}
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel2()
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		r1.Release()
+	}()
+	r2, err = a.WaitAlloc(ctx2, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2.Release()
+}

--- a/get_fs_util.sh
+++ b/get_fs_util.sh
@@ -3,7 +3,7 @@
 set -ex
 
 firstgopath=${GOPATH%%:*}
-pants_release="1.17.0rc0+git42969028"
+pants_release="1.19.0+git382674bd"
 pants_release_url=$(echo $pants_release | sed 's/+/%2B/')
 
 get_fs_util() {

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,7 @@ github.com/twitter/groupcache v0.0.0-20190830195751-11158c6be16d h1:jb3jKhSKeHt9
 github.com/twitter/groupcache v0.0.0-20190830195751-11158c6be16d/go.mod h1:F3VyMCQItbfWsYao7dIdhp2t4hdXRuJIIC7RWWmyijM=
 github.com/twitter/groupcache v0.0.0-20190830224244-7699c26b8c0c h1:xBiot0J/CGFtU93ACvuh6ihwmdEb81tqfqUbJS5O/mQ=
 github.com/twitter/groupcache v0.0.0-20190830224244-7699c26b8c0c/go.mod h1:fcAzz9dBuUo1tHcNFsXFI7dRwSAAKsjCraVFeByrhUc=
+github.com/twitter/groupcache v0.0.0-20190909015146-10d21707d5fe h1:ZmIHV9MFVGpXXZtAmd/tjgoGe8s7EwlQvs+RUJaY7Kc=
 github.com/twitter/groupcache v0.0.0-20190909015146-10d21707d5fe/go.mod h1:fcAzz9dBuUo1tHcNFsXFI7dRwSAAKsjCraVFeByrhUc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8 h1:3SVOIvH7Ae1KRYyQWRjXWJEA9sS/c/pjvH++55Gr648=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/snapshot/bazel/bz_tree.go
+++ b/snapshot/bazel/bz_tree.go
@@ -120,13 +120,18 @@ func (bc *bzCommand) cancel() error {
 
 // Runs fsUtilCmd via an execer with appropriate flags
 func (bc *bzCommand) runCmd(args []string) ([]byte, []byte, execer.ProcessStatus, error) {
+	// local store path required
+	args = append([]string{fsUtilCmdLocalStore, bc.localStorePath}, args...)
+
+	// set connection limit
+	args = append([]string{fsUtilCmdConnLimit, fmt.Sprintf("%d", connLimit)}, args...)
+
+	// add serverAddrs if we resolved any
 	serverAddrs, err := bc.casResolver.ResolveMany(maxResolveToFSUtil)
 	if err != nil {
 		return nil, nil, execer.ProcessStatus{}, err
 	}
 
-	// localStorePath required, add serverAddrs if resolved
-	args = append([]string{fsUtilCmdLocalStore, bc.localStorePath}, args...)
 	if len(serverAddrs) > 0 {
 		for _, addr := range serverAddrs {
 			args = append([]string{fsUtilCmdServerAddr, addr}, args...)

--- a/snapshot/bazel/constants.go
+++ b/snapshot/bazel/constants.go
@@ -19,6 +19,7 @@ const (
 	fsUtilCmdRoot         = "--root"
 	fsUtilCmdLocalStore   = "--local-store-path"
 	fsUtilCmdServerAddr   = "--server-address"
+	fsUtilCmdConnLimit    = "--connection-limit"
 	fsUtilCmdGlobWildCard = "**"
 
 	emptyID = bazel.SnapshotIDPrefix + "-" + bazel.EmptySha + "-0"
@@ -26,4 +27,7 @@ const (
 	// limit amount of CAS addresses resolved in BzFiler calls to fs_util to this
 	// value, in order to limit number of connections
 	maxResolveToFSUtil = 5
+
+	// connection-limit fs_util flag setting
+	connLimit = 3
 )


### PR DESCRIPTION
Preventing client requests from bringing down apiservers using grpc connection/stream/etc settings has been insufficient. Here we limit in the CAS API request handlers themselves based on the size of the requests as determined by the requested digests.

We do this with a new allocator package that manages leases on amounts of bytes. We cap the overall allocator capacity and force CAS requests to reserve amounts from this, or else we return grpc/Unavailable for a request.

This will have a side effect of capping the max size of data read/written via the CAS based on the allocator's max.

Bumps fs_util version.