### PR TITLE
Add cleaner to OSS & introduce entire dir cleaner

### DIFF
--- a/cleaner/cleanup.go
+++ b/cleaner/cleanup.go
@@ -1,0 +1,40 @@
+// Package cleaner provides internal cleanup-related utilities,
+// primarily to limit disk consumption in long-lived workers.
+package cleaner
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/twitter/scoot/cleaner/dirconfig"
+)
+
+// A Cleaner provides cleanup functionality
+type Cleaner interface {
+	Cleanup() error
+}
+
+// Implements Cleaner for doing disk cleanup of directories
+type DiskCleaner struct {
+	DirConfigs []dirconfig.DirConfig
+}
+
+func NewDiskCleaner(dirConfigs []dirconfig.DirConfig) (*DiskCleaner, error) {
+	return &DiskCleaner{
+		DirConfigs: dirConfigs,
+	}, nil
+}
+
+// Cleanup is performed on dirs specified in the DirConfigs.
+// Cleanup does not guarantee usage at or below configured thresholds after running.
+func (d *DiskCleaner) Cleanup() error {
+	var failures []error
+	for _, dc := range d.DirConfigs {
+		if err := dc.CleanDir(); err != nil {
+			failures = append(failures, err)
+		}
+	}
+	if l := len(failures); l > 0 {
+		log.Errorf("Failed to clean %d dir(s). %s", l, failures)
+	}
+	return nil
+}

--- a/cleaner/cleanup_test.go
+++ b/cleaner/cleanup_test.go
@@ -1,0 +1,161 @@
+package cleaner
+
+import (
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/twitter/scoot/cleaner/dirconfig"
+)
+
+func TestCleanupBadConfig(t *testing.T) {
+	// expect error - LowMark == HighMark
+	_, err := dirconfig.NewLastAccessedDirConfig("/this/dir/does/not/exist", 0, 0, 0, 0)
+	if err == nil {
+		t.Fatal("Expected error making new cleaner where LowMarkKB == HighMarkKB == 0")
+	}
+}
+
+func TestCleanupFakeDir(t *testing.T) {
+	// expected to work without errors although Dir doesn't exist
+	dirConf, err := dirconfig.NewLastAccessedDirConfig("/this/dir/does/not/exist", 0, 0, 1, 0)
+	if err != nil {
+		t.Fatalf("Failed to create DirConfig: %s", err)
+	}
+	dc, err := NewDiskCleaner([]dirconfig.DirConfig{dirConf})
+	if err != nil {
+		t.Fatalf("Failed to make new cleaner: %s", err)
+	}
+
+	if err = dc.Cleanup(); err != nil {
+		t.Fatalf("Unexpected error cleaning up non-existent dir: %s", err)
+	}
+}
+
+func TestCleanupAtWatermarks(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "cleaner-test")
+	if err != nil {
+		t.Fatalf("Error setting up tempdir: %s", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	dirConf, err := dirconfig.NewLastAccessedDirConfig(tmp, 64, 2880, 128, 1440)
+	dc, err := NewDiskCleaner([]dirconfig.DirConfig{dirConf})
+	if err != nil {
+		t.Fatalf("Failed to make new cleaner: %s", err)
+	}
+
+	// write files and cleanup:
+	// f0: post retention
+	// size < low mark
+	// expected not to be deleted
+	f0 := filepath.Join(tmp, "f0")
+	makeFile(t, f0, 0, time.Now().Add(time.Duration(-49)*time.Hour))
+	dc.Cleanup()
+	if _, err = os.Stat(f0); os.IsNotExist(err) {
+		t.Fatalf("File %s unexpectedly cleaned up", f0)
+	}
+
+	// write files and cleanup:
+	// f1: post retention
+	// f2: pre retention
+	// combined >= low mark, <= high mark
+	// expected f1 is deleted
+	f1 := filepath.Join(tmp, "f1")
+	f2 := filepath.Join(tmp, "f2")
+	makeFile(t, f1, 32, time.Now().Add(time.Duration(-49)*time.Hour))
+	makeFile(t, f2, 32, time.Now().Add(time.Duration(-25)*time.Hour))
+	dc.Cleanup()
+	if _, err = os.Stat(f1); !os.IsNotExist(err) {
+		t.Fatalf("File %s exists, expected to be cleaned up", f1)
+	}
+	if _, err = os.Stat(f2); os.IsNotExist(err) {
+		t.Fatalf("File %s unexpectedly cleaned up", f2)
+	}
+
+	// write files and cleanup:
+	// f3: post retention
+	// f4: pre retention
+	// combined >= high mark
+	// expected f3 is deleted
+	f3 := filepath.Join(tmp, "f3")
+	f4 := filepath.Join(tmp, "f4")
+	makeFile(t, f3, 64, time.Now().Add(time.Duration(-25)*time.Hour))
+	makeFile(t, f4, 64, time.Now().Add(time.Duration(-12)*time.Hour))
+	dc.Cleanup()
+	if _, err = os.Stat(f3); !os.IsNotExist(err) {
+		t.Fatalf("File %s exists, expected to be cleaned up", f3)
+	}
+	if _, err = os.Stat(f4); os.IsNotExist(err) {
+		t.Fatalf("File %s unexpectedly cleaned up", f4)
+	}
+}
+
+func TestCleanupEntireDir(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "cleaner-test")
+	if err != nil {
+		t.Fatalf("Error setting up tempdir: %s", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	dirConf := []dirconfig.DirConfig{
+		dirconfig.EntireDirConfig{
+			Dir:        tmp,
+			MaxUsageKB: 128,
+		},
+	}
+	dc, err := NewDiskCleaner(dirConf)
+	if err != nil {
+		t.Fatalf("Failed to make new cleaner: %s", err)
+	}
+
+	f0 := filepath.Join(tmp, "f0")
+	makeFile(t, f0, 100, time.Now())
+	dc.Cleanup()
+	if _, err = os.Stat(f0); os.IsNotExist(err) {
+		t.Fatalf("File %s unexpectedly cleaned up", f0)
+	}
+	if _, err = os.Stat(tmp); os.IsNotExist(err) {
+		t.Fatalf("Dir %s exists, expected to be cleaned up", tmp)
+	}
+
+	f1 := filepath.Join(tmp, "f1")
+	makeFile(t, f1, 100, time.Now())
+	dc.Cleanup()
+	if _, err = os.Stat(f1); !os.IsNotExist(err) {
+		t.Fatalf("File %s exists, expected to be cleaned up", f1)
+	}
+	if _, err = os.Stat(tmp); !os.IsNotExist(err) {
+		t.Fatalf("Dir %s exists, expected to be cleaned up", tmp)
+	}
+}
+
+func TestCleanupEntireFakeDir(t *testing.T) {
+	dirConf := dirconfig.EntireDirConfig{
+		Dir:        "/this/dir/does/not/exist",
+		MaxUsageKB: 0,
+	}
+	dc, err := NewDiskCleaner([]dirconfig.DirConfig{dirConf})
+	if err != nil {
+		t.Fatalf("Failed to make new cleaner: %s", err)
+	}
+	if err := dc.Cleanup(); err != nil {
+		t.Fatalf("Unexpected error cleaning up non-existent dir: %s", err)
+	}
+}
+
+func makeFile(t *testing.T, path string, sizeKB uint64, lastAccess time.Time) {
+	buffer := make([]byte, sizeKB*1024)
+	rand.Read(buffer)
+
+	if err := ioutil.WriteFile(path, buffer, 0644); err != nil {
+		t.Fatalf("Failed to generate file: %s", err)
+	}
+
+	if err := os.Chtimes(path, lastAccess, lastAccess); err != nil {
+		t.Fatalf("Failed to chtime on file: %s", err)
+	}
+}

--- a/cleaner/dirconfig/dir_config.go
+++ b/cleaner/dirconfig/dir_config.go
@@ -1,0 +1,45 @@
+package dirconfig
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// A DirConfig defines the manner in which a particular directory should be cleaned
+type DirConfig interface {
+	CleanDir() error
+	GetDir() string
+}
+
+// use posix du to get disk usage of a dir, for simplicity vs syscall or walking dir contents
+func getDiskUsageKB(dir string) (uint64, error) {
+	// shortcut if dir not exist
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return 0, nil
+	}
+
+	name := "du"
+	args := []string{"-sk", dir}
+
+	stdout, err := exec.Command(name, args...).Output()
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			log.Errorf("Failed to run %q %q: %s. Stderr: %s\n", name, args, err, exitError.Stderr)
+		}
+		return 0, err
+	}
+
+	s := string(stdout)
+	arr := strings.Fields(s)
+	if len(arr) != 2 {
+		return 0, errors.New(fmt.Sprintf("Unexpected output from %s: %q (Expected \"<kb> <dir>\")", name, s))
+	}
+
+	return strconv.ParseUint(arr[0], 10, 64)
+}

--- a/cleaner/dirconfig/entire_dir_config.go
+++ b/cleaner/dirconfig/entire_dir_config.go
@@ -1,0 +1,50 @@
+package dirconfig
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Configuration for cleaning disk space of a directory
+// based purely on a maximum usage threshold.
+// When exceeded, the entire directory will be removed.
+type EntireDirConfig struct {
+	Dir        string
+	MaxUsageKB uint64
+}
+
+func (dc EntireDirConfig) GetDir() string { return dc.Dir }
+
+func (dc EntireDirConfig) CleanDir() error {
+	usage, err := getDiskUsageKB(dc.GetDir())
+	if err != nil {
+		return err
+	}
+	if usage > dc.MaxUsageKB {
+		err = dc.cleanDir()
+		if err != nil {
+			return errors.New(fmt.Sprintf("Failed to Cleanup dir: %s. %s", dc.GetDir(), err))
+		}
+	}
+	return nil
+}
+
+func (dc EntireDirConfig) cleanDir() error {
+	name := "rm"
+	args := []string{"-rf", dc.GetDir()}
+
+	log.Infof("Running cleanup for %s with cmd: %s %s\n", dc.GetDir(), name, args)
+	err := exec.Command(name, args...).Run()
+	if err != nil {
+		log.Errorf("Error running cleanup command (this can commonly fail due to non-empty directories): %s\n", err)
+		if errExit, ok := err.(*exec.ExitError); ok {
+			log.Errorf("Cleanup command stderr:\n%s\n", errExit.Stderr)
+		}
+		return err
+	}
+
+	return nil
+}

--- a/cleaner/dirconfig/last_accessed_dir_config.go
+++ b/cleaner/dirconfig/last_accessed_dir_config.go
@@ -58,9 +58,8 @@ func (dc lastAccessedDirConfig) CleanDir() error {
 		if err != nil {
 			return errors.New(fmt.Sprintf("Failed to Cleanup dir: %s. %s", dc.GetDir(), err))
 		}
-	} else {
-		log.Infof("Not cleaning %s, usage %d(KB) under threshold %d(KB)\n", dc.GetDir(), usage, dc.LowMarkKB)
 	}
+	log.Infof("Not cleaning %s, usage %d(KB) under threshold %d(KB)\n", dc.GetDir(), usage, dc.LowMarkKB)
 	return nil
 }
 

--- a/cleaner/updater.go
+++ b/cleaner/updater.go
@@ -1,0 +1,34 @@
+package cleaner
+
+import (
+	"time"
+)
+
+// This Updater is just a means to call cleanup at a set frequency for a worker that
+// otherwise doesn't need Filer updates. In practice we use this for Bazel workers without git repos.
+
+// An Updater for snapshot Filers that invokes a cleaner.Cleaner at the update interval.
+// Implements github.com/twitter/scoot/snapshot.Updater interface
+type CleaningUpdater struct {
+	interval time.Duration
+	cleaner  Cleaner
+}
+
+func NewCleaningUpdater(interval time.Duration, cleaner Cleaner) *CleaningUpdater {
+	return &CleaningUpdater{
+		interval: interval,
+		cleaner:  cleaner,
+	}
+}
+
+func (u *CleaningUpdater) Update() error {
+	if u.cleaner != nil {
+		_ = u.cleaner.Cleanup()
+		// We don't return Cleanup, as it often errors & creates noise
+	}
+	return nil
+}
+
+func (u *CleaningUpdater) UpdateInterval() time.Duration {
+	return u.interval
+}


### PR DESCRIPTION
Problem

There are some directories we need to wipe out entirely as part of our cleaning, as opposed to pruning last accessed files.

Solution

Introduce entire dir cleaner that satisfies DirConfig interface

Result

We will be able to specify the type of cleaning we'd like for specific dirs, either entire dir or last accessed.