### PR TITLE
Fix nil pointer deref

### DIFF
--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -222,7 +222,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 					tags.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID, Tag: cmd.Tag})
 			default:
 				// err is not of type github.com/twitter/scoot/common/errors.Error
-				failedStatus = runner.FailedStatus(id, errors.NewError(codeErr, errors.GenericCheckoutFailureExitCode),
+				failedStatus = runner.FailedStatus(id, errors.NewError(err, errors.GenericCheckoutFailureExitCode),
 					tags.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID, Tag: cmd.Tag})
 			}
 


### PR DESCRIPTION
Problem

codeErr is nil in this case, leading to a nil pointer dereference in FailedStatus where we attempt to access err.Error()

Solution

Use the non-nil err in creation of the error

Result

No more nil pointer deref panics