### PR TITLE
Add more granular scheduler latency stats

### DIFF
--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -266,6 +266,36 @@ const (
 	*/
 	SchedStepLatency_ms = "schedStepLatency_ms"
 
+	/*
+		Amount of time it takes the scheduler to add newly requested jobs to list of jobs currently being handled by scheduler
+	*/
+	SchedAddJobsLatency_ms = "schedAddJobsLatency_ms"
+
+	/*
+		Amount of time it takes the scheduler to update list of removed / added nodes to its worker cluster
+	*/
+	SchedUpdateClusterLatency_ms = "schedUpdateClusterLatency_ms"
+
+	/*
+		Amount of time it takes the scheduler to process all messages in mailbox & execute callbacks (if applicable)
+	*/
+	SchedProcessMessagesLatency_ms = "schedProcessMessagesLatency_ms"
+
+	/*
+		Amount of time it takes the scheduler to complete a checkForCompletedJobs()
+	*/
+	SchedCheckForCompletedLatency_ms = "schedCheckForCompletedLatency_ms"
+
+	/*
+		Amount of time it takes the scheduler to complete a killJobs()
+	*/
+	SchedKillJobsLatency_ms = "schedKillJobsLatency_ms"
+
+	/*
+		Amount of time it takes the scheduler to complete a scheduleTasks()
+	*/
+	SchedScheduleTasksLatency_ms = "schedScheduleTasksLatency_ms"
+
 	/******************************** Worker metrics **************************************/
 	/*
 		The number of runs the worker has currently running

--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -282,17 +282,17 @@ const (
 	SchedProcessMessagesLatency_ms = "schedProcessMessagesLatency_ms"
 
 	/*
-		Amount of time it takes the scheduler to complete a checkForCompletedJobs()
+		Amount of time it takes the scheduler to check if any of the in progress jobs are completed
 	*/
 	SchedCheckForCompletedLatency_ms = "schedCheckForCompletedLatency_ms"
 
 	/*
-		Amount of time it takes the scheduler to complete a killJobs()
+		Amount of time it takes the scheduler to kill all jobs requested to be killed
 	*/
 	SchedKillJobsLatency_ms = "schedKillJobsLatency_ms"
 
 	/*
-		Amount of time it takes the scheduler to complete a scheduleTasks()
+		Amount of time it takes the scheduler to figure out which tasks to schedule next and on which worker
 	*/
 	SchedScheduleTasksLatency_ms = "schedScheduleTasksLatency_ms"
 

--- a/sched/scheduler/cluster_state.go
+++ b/sched/scheduler/cluster_state.go
@@ -211,6 +211,7 @@ func (c *clusterState) getNodeState(nodeId cluster.NodeId) (*nodeState, bool) {
 
 // upate cluster state to reflect added and removed nodes
 func (c *clusterState) updateCluster() {
+	defer c.stats.Latency(stats.SchedUpdateClusterLatency_ms).Time().Stop()
 	select {
 	case updates, ok := <-c.updateCh:
 		if !ok {


### PR DESCRIPTION
Problem

We don't know what the scheduler is spending its time on when it gets backed up

Solution

Add more granular scheduler latency stats

Result

We will be able to dig into what steps the scheduler is spending its time on