### PR TITLE
bazel/parse - add json field specifiers to op wrapper struct

### DIFF
--- a/bazel/execution/parse.go
+++ b/bazel/execution/parse.go
@@ -179,9 +179,9 @@ func OperationToJson(op *longrunning.Operation) ([]byte, error) {
 }
 
 type operationWrapper struct {
-	Name     string
-	Metadata *remoteexecution.ExecuteOperationMetadata
-	Done     bool
+	Name     string                                    `json:"name"`
+	Metadata *remoteexecution.ExecuteOperationMetadata `json:"metadata"`
+	Done     bool                                      `json:"done"`
 	Result   *operationResultWrapper
 }
 


### PR DESCRIPTION
This matches the encoded json field names between an encoded operationWrapper and naively marshalled longrunning.Operation struct.