### PR TITLE
Jbruno/dpt126129deploy apiserver benchmark service

### DIFF
--- a/common/stats/stats.go
+++ b/common/stats/stats.go
@@ -125,8 +125,6 @@ type StatsReceiver interface {
 	// Construct a JSON string by marshaling the registry.
 	Render(pretty bool) []byte
 
-	// Construct a JSON string from the registry (ignore latching) without resetting the registry
-	RenderNoClear(pretty bool) []byte
 }
 
 //
@@ -309,14 +307,6 @@ func (s *defaultStatsReceiver) Render(pretty bool) []byte {
 		clear(s.registry) // reset on every call to render when not latched.
 	}
 	return stats
-}
-
-/*
-Render the stats in the registry without clearing the registry.  This is used by performance testing
-to allow users to query stats at random times and not impact the overall test's stats handling.
-*/
-func (s *defaultStatsReceiver) RenderNoClear(pretty bool) []byte {
-	return s.render(pretty)
 }
 
 // Append to existing scope and scrub slashes

--- a/common/stats/stats.go
+++ b/common/stats/stats.go
@@ -124,7 +124,6 @@ type StatsReceiver interface {
 
 	// Construct a JSON string by marshaling the registry.
 	Render(pretty bool) []byte
-
 }
 
 //

--- a/perftests/apiserver/loadtest/apiserver_benchmarker/main.go
+++ b/perftests/apiserver/loadtest/apiserver_benchmarker/main.go
@@ -1,5 +1,5 @@
 /*
-load_tester is the cli  for generating load on the apiserver.
+apiserver_benchmarker is the cli  for generating load on the apiserver.
 
 The load scenario is parameterized in terms of action (upload/download/both),
 file size (min, max), number of (concurrent) actions, frequency for running a scenario (once, every N minutes)
@@ -10,7 +10,7 @@ The command line options allow the user to request that the test be run to:
 	- can be run as an http service waiting get requests to trigger the test.  See perftests/apiserver/loadtest/http_api
 
 sample run:
-load_tester -action=both -cas_addr=<apiserver> -log_level=info -max_data_size=1000 -min_data_size=10 -num_times=30
+apiserver_benchmarker -action=both -cas_addr=<apiserver> -log_level=info -max_data_size=1000 -min_data_size=10 -num_times=30
 */
 package main
 
@@ -38,12 +38,7 @@ func main() {
 		return
 	}
 
-	level, err := log.ParseLevel(a.LogLevel)
-	if err != nil {
-		log.Fatal(err)
-		return
-	}
-	log.SetLevel(level)
+	log.SetLevel(a.LogLevel)
 
 	// make the load tester
 	lt := loadtest.MakeApiserverLoadTester(a)
@@ -74,7 +69,7 @@ func argParse() (*loadtest.Args, bool, string, string, error) {
 	numTimes := flag.Int("num_times", 10, "number of times the action should be taken (concurrently)")
 	batch := flag.Bool("batch", false, "Use the batch api consolidating all upload or download actions in one CAS call. (default false)")
 	frequencyFlag := flag.Int("freq", 0,
-		"0 requests to run the test once, > 0 requests to run 100 iterations of the test every <freq> minutes")
+		"0 requests to run the test once, > 0 requests to run 100 iterations of the test every <freq> seconds")
 	totalTime := flag.Int("total_time", 30, "Total number of minutes to allow the test to run (default 30)")
 	casGrpcAddr := flag.String("cas_addr", "", "cas grpc address")
 	startAsServerFlag := flag.Bool("start_as_http_server", false, "start an http service listening for get to trigger the test. Default false.")
@@ -82,8 +77,14 @@ func argParse() (*loadtest.Args, bool, string, string, error) {
 	portFlag := flag.String("port", "", "The (load test) server's portFlag.")
 	flag.Parse()
 
+	level, err := log.ParseLevel(*logLevelFlag)
+	if err != nil {
+		log.Fatal(err)
+		return nil, false, "", "", fmt.Errorf("bad log level: %s", *logLevelFlag)
+	}
+
 	a := &loadtest.Args{
-		LogLevel:    strings.ToLower(*logLevelFlag),
+		LogLevel:    level,
 		Action:      strings.ToLower(*actionFlag),
 		DataSizeMin: *dataSizeMinFlag,
 		DataSizeMax: *dataSizeMaxFlag,
@@ -144,11 +145,12 @@ func validateArgs(a *loadtest.Args, startAsServer bool, port string) bool {
 		err = true
 	}
 
-	if startAsServer {
+	if !startAsServer {
 		if a.CasGrpcAddr == "" {
 			log.Fatalf("casGrpcAddr must be defined.")
 			err = true
 		}
+	} else {
 		if port == "" {
 			log.Fatalf("port must be defined.")
 			err = true

--- a/perftests/apiserver/loadtest/http_api.go
+++ b/perftests/apiserver/loadtest/http_api.go
@@ -57,6 +57,12 @@ func (lt *ApiserverLoadTester) startTest(w http.ResponseWriter, r *http.Request)
 	lt.numActions = lt.getIntParam("num_times", 10, r)
 	lt.freq = lt.getIntParam("freq", 0, r)
 	lt.totalTime = lt.getIntParam("total_time", 30, r)
+	lt.casGrpcAddr = lt.getStringParam("cas_addr", "", r)
+	if lt.casGrpcAddr == "" {
+		resp := "cas_addr parameter must be supplied"
+		json.NewEncoder(w).Encode(resp)
+		return
+	}
 
 	go func() {
 		lt.RunLoadTest()

--- a/perftests/apiserver/loadtest/load_tester.go
+++ b/perftests/apiserver/loadtest/load_tester.go
@@ -142,9 +142,9 @@ func MakeApiserverLoadTester(a *Args) *ApiserverLoadTester {
 	lt.stat = statsReceiver.Scope("cas_streaming")
 
 	tdir := os.TempDir()
-	_, err := os.Open(fmt.Sprintf("%sCloudExec", tdir))
+	_, err := os.Open(fmt.Sprintf("%sscoot", tdir))
 	if os.IsNotExist(err) {
-		os.Mkdir(fmt.Sprintf("%sCloudExec", tdir), 0777)
+		os.Mkdir(fmt.Sprintf("%sscoot", tdir), 0777)
 	}
 	lt.statsFile = fmt.Sprintf("%sCloudExec/apiserver_load_test.csv", tdir)
 
@@ -196,7 +196,7 @@ func (lt *ApiserverLoadTester) RunLoadTest() error {
 		return nil
 	}
 
-	// set up a timer to signal running the test every <freq> minutes
+	// set up a timer to signal running the test every <freq> seconds
 	tFreq := time.Duration(lt.freq) * time.Second
 	ticker := time.NewTicker(tFreq)
 	go func() {

--- a/perftests/apiserver/loadtest/load_tester.go
+++ b/perftests/apiserver/loadtest/load_tester.go
@@ -44,6 +44,23 @@ const (
 	PauseBetweenIterations
 )
 
+func (sc StatusCode) String() string {
+	if sc == WaitingToStart {
+		return "WaitingToStart"
+	} else if sc == Initializing {
+		return "Initializing"
+	} else if sc == InitUpload {
+		return "InitUpload"
+	} else if sc == CreatingGoRoutines {
+		return "CreatingGoRoutines"
+	} else if sc == RunningActions {
+		return "RunningActions"
+	} else if sc == PauseBetweenIterations {
+		return "PauseBetweenIterations"
+	}
+	return fmt.Sprintf("bad status code: %d", sc)
+}
+
 type Status struct {
 	code StatusCode
 	desc string
@@ -54,14 +71,15 @@ ApiserverLoadTester is the object that runs the load test.  The RunLoadTest() fu
 */
 type ApiserverLoadTester struct {
 	// cli args
-	action         string // the test's action (upload, download, both)
-	useBatchApi    bool   // use the CAS batch api
-	minDataSetSize int    // the minimum data set size to use during the test
-	maxDataSetSize int    // the maximium data set size to use during the test
-	numActions     int    // the number of concurrent upload/downloads we want to trigger
-	freq           int    // the frequency to repeat the test (0 = run once)
-	totalTime      int    // the total elapsed time to allow repeating tests to run
-	casGrpcAddr    string // the cas addr (<hostname>:<port>)
+	action         string    // the test's action (upload, download, both)
+	useBatchApi    bool      // use the CAS batch api
+	minDataSetSize int       // the minimum data set size to use during the test
+	maxDataSetSize int       // the maximium data set size to use during the test
+	numActions     int       // the number of concurrent upload/downloads we want to trigger
+	freq           int       // the frequency to repeat the test (0 = run once)
+	totalTime      int       // the total elapsed time to allow repeating tests to run
+	casGrpcAddr    string    // the cas addr (<hostname>:<port>)
+	log_level      log.Level // current log level
 
 	// data set fields
 	data                []byte   // the raw data set all uploads are derived from
@@ -87,7 +105,7 @@ type ApiserverLoadTester struct {
 }
 
 type Args struct {
-	LogLevel    string
+	LogLevel    log.Level
 	Action      string
 	DataSizeMin int
 	DataSizeMax int
@@ -111,17 +129,16 @@ func MakeApiserverLoadTester(a *Args) *ApiserverLoadTester {
 		killRequested:  false,
 		status:         WaitingToStart,
 		iterCnt:        0,
+		log_level:      a.LogLevel,
 	}
 
 	// get the cas connection
-	lt.dialer = dialer.NewConstantResolver(lt.casGrpcAddr)
+	log.Debugf("creating dialer with addr:%s", lt.casGrpcAddr)
 	lt.casCli = cas.MakeCASClient()
 
 	// initialize thes stats
 	statsReceiver, _ := stats.NewCustomStatsReceiver(stats.NewFinagleStatsRegistry, 0)
 	lt.stat = statsReceiver.Scope("cas_streaming")
-
-	lt.stopTestIterations = make(chan bool)
 
 	tdir := os.TempDir()
 	_, err := os.Open(fmt.Sprintf("%sCloudExec", tdir))
@@ -142,28 +159,31 @@ func (lt *ApiserverLoadTester) RunLoadTest() error {
 		timing the frequency, then in this process loop running the next iterations when a timer sends a signal on its
 		channel, or stopping when time is up or a kill request is received
 	*/
+	log.SetLevel(lt.log_level)
+
 	lt.status = Initializing
 
-	_, err := os.Stat(lt.statsFile)
-	if os.IsExist(err) {
-		os.Remove(lt.statsFile)
-	}
+	log.Debugf("creating dialer: %s", lt.casGrpcAddr)
+	lt.dialer = dialer.NewConstantResolver(lt.casGrpcAddr)
+
+	lt.ResetStatsFile()
+
+	lt.stopTestIterations = make(chan bool)
 
 	// initialize the data sizes and data set for the test
-	err = lt.initTestData()
+	err := lt.initTestData()
 	if err != nil {
+		lt.resetStatusToWaitingToStart()
 		return fmt.Errorf("couldn't initialize the test data:%s", err.Error())
 	}
 
 	if lt.getKillRequested() {
-		lt.drainStopChAndResetStatus()
+		lt.resetStatusToWaitingToStart()
 		return nil
 	}
 
 	if lt.freq == 0 {
 		lt.runOneIteration() // run the test once
-		lt.drainStopChAndResetStatus()
-		// reset for next test request
 		lt.resetStatusToWaitingToStart()
 		return nil
 	}
@@ -171,38 +191,43 @@ func (lt *ApiserverLoadTester) RunLoadTest() error {
 	// run the test once
 	lt.runOneIteration()
 	if lt.getKillRequested() {
-		lt.drainStopChAndResetStatus()
+		lt.resetStatusToWaitingToStart()
 		return nil
 	}
 
 	// set up a timer to signal running the test every <freq> minutes
-	tFreq := time.Duration(lt.freq) * time.Minute
+	tFreq := time.Duration(lt.freq) * time.Second
 	ticker := time.NewTicker(tFreq)
 	go func() {
 		time.Sleep(time.Duration(lt.totalTime) * time.Minute)
 		ticker.Stop()
-		if !lt.getKillRequested() { // if we already have killRequested, don't try to put stop signal on channel
-			// stopTestIterations the test after totalTime
-			lt.stopTestIterations <- true
-		}
+		lt.stopTestIterations <- true
 	}()
 
 	// loop running the test on the timer signals until stop is received
-	notDone := true
-	for notDone {
+	cnt := 0
+	for {
 		select {
 		case <-lt.stopTestIterations:
-			notDone = false
+			log.Infof("stopping after %d iterations", cnt)
+			lt.resetStatusToWaitingToStart()
+			return nil
 		case <-ticker.C:
 			lt.runOneIteration()
+			log.Infof("%d iteration done, waiting up to %d seconds for next iteration", cnt, lt.freq)
+			cnt++
 		default:
 			time.Sleep(2 * time.Second)
 		}
 	}
+}
 
-	// reset for next test request
-	lt.resetStatusToWaitingToStart()
-	return nil
+func (lt *ApiserverLoadTester) ResetStatsFile() error {
+	_, err := os.Stat(lt.statsFile)
+	if !os.IsNotExist(err) {
+		os.Remove(lt.statsFile)
+	}
+	return err
 }
 
 func (lt *ApiserverLoadTester) getKillRequested() bool {
@@ -218,18 +243,10 @@ func (lt *ApiserverLoadTester) setKillRequested(val bool) {
 }
 
 func (lt *ApiserverLoadTester) resetStatusToWaitingToStart() {
+	log.Infof("reset status to waiting to start")
 	lt.status = WaitingToStart
 	lt.setKillRequested(false)
 	lt.iterCnt = 0
-}
-
-func (lt *ApiserverLoadTester) drainStopChAndResetStatus() {
-	select {
-	case <-lt.stopTestIterations: // drain the lt.stopTestIterations channel
-	default:
-	}
-	log.Infof("kill request channel was drained")
-	lt.resetStatusToWaitingToStart()
 }
 
 func (lt *ApiserverLoadTester) runOneIteration() {
@@ -255,9 +272,18 @@ func (lt *ApiserverLoadTester) runOneIteration() {
 			dIdx = int(rand.Float32() * float32(len(lt.initUploadDigestIds)))
 		}
 		if lt.useBatchApi {
-			lt.accumulateBatchContent(dIdx)
+			err := lt.accumulateBatchContent(dIdx)
+			if err != nil {
+				log.Error(err)
+				return
+			}
 			if i == lt.numActions-1 {
-				go lt.performBatchAction(startCh, actionDoneCh)
+				go func() {
+					err := lt.performBatchAction(startCh, actionDoneCh)
+					if err != nil {
+						log.Error(err)
+					}
+				}()
 			}
 		} else {
 			go lt.performTestAction(dIdx, startCh, actionDoneCh)
@@ -282,7 +308,7 @@ func (lt *ApiserverLoadTester) writeStatsToFile() {
 
 	// convert to comma delimited string
 	statsMap := make(map[string]interface{})
-	json.Unmarshal([]byte(statsJson), &statsMap) // make into a map (statsMap)
+	json.Unmarshal(statsJson, &statsMap) // make into a map (statsMap)
 
 	// sort the map to print in same order each time
 	keys := make([]string, 0)
@@ -359,7 +385,8 @@ func (lt *ApiserverLoadTester) performTestAction(dataIdx int, startCh chan struc
 func (lt *ApiserverLoadTester) performBatchAction(startCh chan struct{}, doneCh chan int) error {
 	<-startCh
 	if lt.action == "upload" {
-		log.Debugf("uploading:%d entries", len(lt.batchContents))
+		addr, _ := lt.dialer.Resolve()
+		log.Debugf("uploading:%d entries to addr %s", len(lt.batchContents), addr)
 		defer lt.stat.Latency(BatchUploadLatency).Time().Stop()
 		_, err := lt.casCli.BatchUpdateWrite(lt.dialer, lt.batchContents,
 			backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 5))
@@ -399,7 +426,7 @@ func (lt *ApiserverLoadTester) accumulateBatchContent(dataIdx int) error {
 	}
 
 	if lt.getKillRequested() {
-		return fmt.Errorf("Kill request received, batch upload skipped")
+		return fmt.Errorf("kill request received, batch upload skipped")
 	}
 
 	return nil
@@ -410,14 +437,14 @@ func (lt *ApiserverLoadTester) uploadADataSet(numKBytes int) (string, error) {
 	// make the upload content unique: update the first KBYTE bytes of the common data set with a random set of values
 	theData, digest := lt.makeUploadContent(numKBytes)
 	if lt.getKillRequested() {
-		return "", fmt.Errorf("Kill request received, upload skipped")
+		return "", fmt.Errorf("kill request received, upload skipped")
 	}
 	log.Debugf("uploading:%v", digest)
 	defer lt.stat.Latency(UploadLatency).Time().Stop()
 	err := lt.casCli.ByteStreamWrite(lt.dialer, digest, theData[:],
 		backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 5))
 	if err != nil {
-		return "", fmt.Errorf("Upload error:%s", err.Error())
+		return "", fmt.Errorf("upload error:%s", err.Error())
 	}
 	return digest.Hash, nil
 }
@@ -442,7 +469,7 @@ func (lt *ApiserverLoadTester) downloadAFile(digestId string) error {
 	digest := &remoteexecution.Digest{Hash: digestId}
 
 	if lt.getKillRequested() {
-		return fmt.Errorf("Kill request received, download skipped")
+		return fmt.Errorf("kill request received, download skipped")
 	}
 	log.Debugf("downloading:%v", digest)
 	defer lt.stat.Latency(DownloadLatency).Time().Stop()
@@ -485,18 +512,20 @@ func (lt *ApiserverLoadTester) initTestData() error {
 	lt.data = lt.makeDummyData(lt.dataSizes[len(lt.dataSizes)-1] * KBYTE) // assume TestDataSizes in ascending order
 
 	if lt.action == "download" || lt.action == "both" {
+		log.Infof("uploading dummy files for downloads")
 		lt.status = InitUpload
 		lt.initUploadDigestIds = make([]string, len(lt.dataSizes))
 		for i := 0; i < len(lt.dataSizes); i++ {
 			// upload the data so it is available for download
 			digestId, err := lt.uploadADataSet(lt.dataSizes[i])
 			if err != nil {
-				return fmt.Errorf("Couldn't upload the %d sized initial data set:%s", lt.dataSizes[i], err.Error())
+				return fmt.Errorf("couldn't upload the %d sized initial data set:%s", lt.dataSizes[i], err.Error())
 			}
 			lt.initUploadDigestIds[i] = digestId
 		}
 	}
 
+	log.Infof("dummy files have been uploaded")
 	return nil
 }
 
@@ -522,16 +551,16 @@ func (lt *ApiserverLoadTester) GetStatus() Status {
 	case PauseBetweenIterations:
 		return Status{PauseBetweenIterations, fmt.Sprintf("Iteration %d: Pause after iteration.", lt.iterCnt)}
 	default:
-		stats, err := ioutil.ReadFile(lt.statsFile)
+		statsF, err := ioutil.ReadFile(lt.statsFile)
 		if err != nil {
 			return Status{code: WaitingToStart, desc: fmt.Sprintf("%s", err.Error())}
 		}
-		return Status{code: WaitingToStart, desc:string(stats)}
+		return Status{code: WaitingToStart, desc: string(statsF)}
 	}
 }
 
 func (s Status) String() string {
-	return fmt.Sprintf("{'code': %d; 'desc':'%s'}", s.code, s.desc)
+	return fmt.Sprintf("{'code': %s; 'desc':'%s'}", s.code.String(), s.desc)
 }
 
 /*

--- a/perftests/apiserver/loadtest/load_tester.go
+++ b/perftests/apiserver/loadtest/load_tester.go
@@ -28,6 +28,7 @@ const (
 	BatchUploadLatency   = "batch_write_latency"
 	BatchDownloadLatency = "batch_read_latency"
 	KBYTE                = 1024
+	MaxTestSize          = 2000000000 // 2gb max data size for a test
 )
 
 var TestDataSizes = [3]int{1, 10, 1000} // these sizes are 1kb units: 1kb, 10kb, 1m test files
@@ -491,6 +492,11 @@ func (lt *ApiserverLoadTester) makeDummyData(size int) []byte {
 
 // fill the dataSizes array in ApiserverLoadTester with the data sizes selected for the test
 func (lt *ApiserverLoadTester) initTestData() error {
+
+	if lt.maxDataSetSize*lt.numActions > MaxTestSize {
+		return fmt.Errorf("the test scenario exceeds the %d limit, please reduce the data sizes or number of actions",
+			MaxTestSize)
+	}
 
 	// get data set sizes from cli min,max range
 	j := 0

--- a/perftests/apiserver/loadtest/load_tester.go
+++ b/perftests/apiserver/loadtest/load_tester.go
@@ -142,11 +142,11 @@ func MakeApiserverLoadTester(a *Args) *ApiserverLoadTester {
 	lt.stat = statsReceiver.Scope("cas_streaming")
 
 	tdir := os.TempDir()
-	_, err := os.Open(fmt.Sprintf("%sscoot", tdir))
+	_, err := os.Open(fmt.Sprintf("%s", tdir))
 	if os.IsNotExist(err) {
-		os.Mkdir(fmt.Sprintf("%sscoot", tdir), 0777)
+		os.Mkdir(fmt.Sprintf("%s", tdir), 0777)
 	}
-	lt.statsFile = fmt.Sprintf("%sCloudExec/apiserver_load_test.csv", tdir)
+	lt.statsFile = fmt.Sprintf("%s/apiserver_load_test.csv", tdir)
 
 	return &lt
 }


### PR DESCRIPTION
submitting updates to the apiserver benchmark tool (from lessons learned using it):
- ability to set logging level with each test request when deployed as a service (helps debugging)
- ability to direct the each test to a different apiserver when deployed as a service
- code cleanup (names, dead code)
- fixed stats reporting when deployed as a service: reset stats at the beginning of each test, get stats from local file so as to report stats on repeated runs of a test.