### PR TITLE
Add test for avg durations and fix it

### DIFF
--- a/scheduler/server/job_state.go
+++ b/scheduler/server/job_state.go
@@ -49,7 +49,7 @@ func (s taskStatesByDuration) Less(i, j int) bool {
 // Creates a New Job State based on the specified Job and Saga
 // The jobState will reflect any previous progress made on this job and logged to the Sagalog
 // Note: taskDurations is optional and only used to enable sorts using taskStatesByDuration above.
-func newJobState(job *domain.Job, saga *saga.Saga, taskDurations map[string]averageDuration) *jobState {
+func newJobState(job *domain.Job, saga *saga.Saga, taskDurations map[string]*averageDuration) *jobState {
 	j := &jobState{
 		Job:            job,
 		Saga:           saga,
@@ -63,9 +63,13 @@ func newJobState(job *domain.Job, saga *saga.Saga, taskDurations map[string]aver
 	}
 
 	for _, taskDef := range job.Def.Tasks {
-		duration := taskDurations[taskDef.TaskID].duration // This is safe since the map value is not a pointer.
-		if duration == 0 {
-			duration = math.MaxInt64 // Set max duration if we don't have the average duration.
+		var duration time.Duration
+		if taskDurations != nil {
+			if avgDur, ok := taskDurations[taskDef.TaskID]; !ok || avgDur.duration == 0 {
+				taskDurations[taskDef.TaskID] = &averageDuration{}
+				taskDurations[taskDef.TaskID].update(math.MaxInt64) // Set max duration if we don't have the average duration.
+			}
+			duration = taskDurations[taskDef.TaskID].duration
 		}
 		task := &taskState{
 			JobId:         job.Id,

--- a/scheduler/server/stateful_scheduler.go
+++ b/scheduler/server/stateful_scheduler.go
@@ -132,7 +132,7 @@ type averageDuration struct {
 	duration time.Duration
 }
 
-func (ad averageDuration) update(d time.Duration) {
+func (ad *averageDuration) update(d time.Duration) {
 	ad.count++
 	ad.duration = ad.duration + time.Duration(int64(d-ad.duration)/ad.count)
 }
@@ -163,9 +163,9 @@ type statefulScheduler struct {
 	clusterState   *clusterState
 	inProgressJobs []*jobState // ordered list (by jobId) of jobs being scheduled.  Note: it might be
 	// no tasks have started yet.
-	requestorMap     map[string][]*jobState     // map of requestor to all its jobs. Default requestor="" is ok.
-	requestorHistory map[string][]string        // map of join(requestor, basis) to new tags in the order received.
-	taskDurations    map[string]averageDuration // map of taskId to averageDuration (note: we unconditionally dereference this).
+	requestorMap     map[string][]*jobState      // map of requestor to all its jobs. Default requestor="" is ok.
+	requestorHistory map[string][]string         // map of join(requestor, basis) to new tags in the order received.
+	taskDurations    map[string]*averageDuration // map of taskId to averageDuration
 
 	requestorsCounts map[string]map[string]int // map of requestor to job and task stats counts
 
@@ -287,7 +287,7 @@ func NewStatefulScheduler(
 		inProgressJobs:   make([]*jobState, 0),
 		requestorMap:     make(map[string][]*jobState),
 		requestorHistory: make(map[string][]string),
-		taskDurations:    make(map[string]averageDuration),
+		taskDurations:    make(map[string]*averageDuration),
 		requestorsCounts: make(map[string]map[string]int),
 		stat:             stat,
 	}

--- a/scheduler/server/stateful_scheduler_test.go
+++ b/scheduler/server/stateful_scheduler_test.go
@@ -742,3 +742,16 @@ func getDepsWithSimWorker() (*schedulerDeps, []*execers.SimExecer) {
 	}, nil
 
 }
+
+func TestUpdateAvgDuration(t *testing.T) {
+	taskDurations := make(map[string]*averageDuration)
+	taskDurations["foo"] = &averageDuration{
+		count:    1,
+		duration: 5 * time.Second,
+	}
+	taskDurations["foo"].update(21 * time.Second)
+	taskDurations["foo"].update(25 * time.Second)
+	if taskDurations["foo"].duration != 17*time.Second {
+		t.Fatalf("Expected 17 seconds, got %v", taskDurations["foo"].duration)
+	}
+}


### PR DESCRIPTION
The scheduler has a mechanism by which to track average duration for taskIDs. However, it wasn't working, as it was using a non-pointer averageDuration struct. This PR adds a test to ensure it is working as expected, and updates its usage.