### PR TITLE
Timeout on exec fs_util commands and wait for ingests to return during abort

### DIFF
--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -503,6 +503,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 
 			// Process Bazel uploads of std* output and other data to CAS
 			ingestCh := make(chan interface{})
+			// TODO ASYNC
 			go func() {
 				actionResult, err := postProcessBazel(inv.filerMap[runType].Filer, cmd, co.Path(), stdout, stderr, st, rts, inv.rID)
 				if err != nil {

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -471,6 +471,8 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 				if err := inv.filerMap[runType].Filer.CancelIngest(); err != nil {
 					log.Errorf("Error canceling ingest: %s", err)
 				}
+				// Cancel call above should cause ingest to exit sooner, but still wait for return to release worker
+				<-ingestCh
 				return runner.AbortStatus(id, tags.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID, Tag: cmd.Tag})
 			case res := <-ingestCh:
 				switch res.(type) {
@@ -503,7 +505,6 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 
 			// Process Bazel uploads of std* output and other data to CAS
 			ingestCh := make(chan interface{})
-			// TODO ASYNC
 			go func() {
 				actionResult, err := postProcessBazel(inv.filerMap[runType].Filer, cmd, co.Path(), stdout, stderr, st, rts, inv.rID)
 				if err != nil {
@@ -516,10 +517,11 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 			var actionResult *bazelapi.ActionResult
 			select {
 			case <-abortCh:
-				// postProcessBazel actions here can be calling Filer.Ingest on Bazel OutputFiles/Dirs
 				if err := inv.filerMap[runType].Filer.CancelIngest(); err != nil {
 					log.Errorf("Error canceling ingest: %s", err)
 				}
+				// Cancel call above should cause ingest to exit sooner, but still wait for return to release worker
+				<-ingestCh
 				return runner.AbortStatus(id, tags.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID, Tag: cmd.Tag})
 			case res := <-ingestCh:
 				switch res.(type) {

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -267,7 +267,6 @@ func (c *QueueController) enqueue(cmd *runner.Command) (runner.RunStatus, error)
 	return st, nil
 }
 
-// TODO is it possible to Abort and start a new Run while something hasn't totally exited?
 // Abort kills the given run, returning its final status.
 func (c *QueueController) Abort(run runner.RunID) (runner.RunStatus, error) {
 	resultCh := make(chan result)

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -267,6 +267,7 @@ func (c *QueueController) enqueue(cmd *runner.Command) (runner.RunStatus, error)
 	return st, nil
 }
 
+// TODO is it possible to Abort and start a new Run while something hasn't totally exited?
 // Abort kills the given run, returning its final status.
 func (c *QueueController) Abort(run runner.RunID) (runner.RunStatus, error) {
 	resultCh := make(chan result)

--- a/snapshot/bazel/bz_tree.go
+++ b/snapshot/bazel/bz_tree.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -28,6 +29,7 @@ type bzCommand struct {
 	execer  execer.Execer
 	mu      sync.Mutex
 	abortCh chan struct{}
+	timeout time.Duration
 }
 
 func makeBzCommand(storePath string, resolver dialer.Resolver) *bzCommand {
@@ -35,6 +37,7 @@ func makeBzCommand(storePath string, resolver dialer.Resolver) *bzCommand {
 		localStorePath: storePath,
 		casResolver:    resolver,
 		execer:         osexecer.NewExecer(),
+		timeout:        fsUtilTimeoutSec * time.Second,
 	}
 }
 
@@ -154,12 +157,9 @@ func (bc *bzCommand) runCmd(args []string) ([]byte, []byte, execer.ProcessStatus
 	return stdout.Bytes(), stderr.Bytes(), st, nil
 }
 
-// TODO we can have "cancel()" sent when we aren't in a critical section - what happens then?
-// how can that ultimately lead to a nil channel close panic?
-// intent is to not be able to reuse this - the ch's don't really guarantee that.
-// Bug was, somehow uploading outputs at the same time we were doing a checkout (happened after an Abort during prev output upload)
 func (bc *bzCommand) exec(c execer.Command) execer.ProcessStatus {
 	bc.startupCh()
+
 	p, err := bc.execer.Exec(c)
 
 	if err != nil {
@@ -172,6 +172,10 @@ func (bc *bzCommand) exec(c execer.Command) execer.ProcessStatus {
 	processCh := make(chan execer.ProcessStatus, 1)
 	go func() { processCh <- p.Wait() }()
 	var st execer.ProcessStatus
+
+	// triggers a send on abortCh if timeout is reached
+	timeoutTimer := time.AfterFunc(bc.timeout, func() { bc.cancel() })
+	defer timeoutTimer.Stop()
 
 	select {
 	case st = <-processCh:

--- a/snapshot/bazel/bz_tree.go
+++ b/snapshot/bazel/bz_tree.go
@@ -154,6 +154,10 @@ func (bc *bzCommand) runCmd(args []string) ([]byte, []byte, execer.ProcessStatus
 	return stdout.Bytes(), stderr.Bytes(), st, nil
 }
 
+// TODO we can have "cancel()" sent when we aren't in a critical section - what happens then?
+// how can that ultimately lead to a nil channel close panic?
+// intent is to not be able to reuse this - the ch's don't really guarantee that.
+// Bug was, somehow uploading outputs at the same time we were doing a checkout (happened after an Abort during prev output upload)
 func (bc *bzCommand) exec(c execer.Command) execer.ProcessStatus {
 	bc.startupCh()
 	p, err := bc.execer.Exec(c)

--- a/snapshot/bazel/constants.go
+++ b/snapshot/bazel/constants.go
@@ -32,5 +32,5 @@ const (
 	connLimit = 3
 
 	// max time execd fs_util commands can run before timing them out
-	fsUtilTimeoutSec = 1800
+	fsUtilTimeoutSec = 600
 )

--- a/snapshot/bazel/constants.go
+++ b/snapshot/bazel/constants.go
@@ -30,4 +30,7 @@ const (
 
 	// connection-limit fs_util flag setting
 	connLimit = 3
+
+	// max time execd fs_util commands can run before timing them out
+	fsUtilTimeoutSec = 1800
 )


### PR DESCRIPTION
This should help address a couple variants of issues we've been seeing.

The first is panics in bz_tree indicating bzCommands are being reused when that's not intended. It's clear from the invoker that asynchronous ingests can be left running in Abort scenarios, so we wait blocking after calling Cancel to make sure the worker can't run new tasks until it's finished.

We've also seen cases where fs_util has been running for ~days on end - this is rare, but essentially bricks the worker. For now, add a 30 minute timeout for all exec'd fs_util calls.