### PR TITLE
kill the worker on any repeated git-based error

### DIFF
--- a/common/errors/exit_codes.go
+++ b/common/errors/exit_codes.go
@@ -9,7 +9,6 @@ const (
 	GenericCheckoutFailureExitCode = 210
 	CleanFailureExitCode           = 211
 	CheckoutFailureExitCode        = 212
-	ReleaseCheckoutFailureExitCode = 213
 	BundleUploadFailureExitCode    = 214
 	ReadFileAllFailureExitCode     = 215
 	ExportGitCommitFailureExitCode = 216

--- a/common/errors/exit_codes.go
+++ b/common/errors/exit_codes.go
@@ -9,6 +9,7 @@ const (
 	GenericCheckoutFailureExitCode = 210
 	CleanFailureExitCode           = 211
 	CheckoutFailureExitCode        = 212
+	ReleaseCheckoutFailureCode     = 213
 	BundleUploadFailureExitCode    = 214
 	ReadFileAllFailureExitCode     = 215
 	ExportGitCommitFailureExitCode = 216

--- a/perftests/scheduler_simulator/fake_worker_cli.go
+++ b/perftests/scheduler_simulator/fake_worker_cli.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/twitter/scoot/cloud/cluster"
+	"github.com/twitter/scoot/common/errors"
 	"github.com/twitter/scoot/common/log/tags"
 	"github.com/twitter/scoot/runner"
 )
@@ -88,7 +89,7 @@ func (fw *FakeWorker) Run(cmd *runner.Command) (runner.RunStatus, error) {
 		StdoutRef:    "",
 		StderrRef:    "",
 		SnapshotID:   "",
-		ExitCode:     exitCode,
+		ExitCode:     errors.ExitCode(exitCode),
 		Error:        "",
 		ActionResult: nil,
 	}

--- a/runner/execer/execer.go
+++ b/runner/execer/execer.go
@@ -3,6 +3,7 @@ package execer
 import (
 	"io"
 
+	"github.com/twitter/scoot/common/errors"
 	"github.com/twitter/scoot/common/log/tags"
 )
 
@@ -66,6 +67,6 @@ type Process interface {
 // TODO when are these valid in what cases?
 type ProcessStatus struct {
 	State    ProcessState
-	ExitCode int
+	ExitCode errors.ExitCode
 	Error    string
 }

--- a/runner/execer/execers/done.go
+++ b/runner/execer/execers/done.go
@@ -1,6 +1,9 @@
 package execers
 
-import "github.com/twitter/scoot/runner/execer"
+import (
+	"github.com/twitter/scoot/common/errors"
+	"github.com/twitter/scoot/runner/execer"
+)
 
 // Creates a new doneExecer.
 func NewDoneExecer() *DoneExecer {
@@ -12,7 +15,7 @@ func NewDoneExecer() *DoneExecer {
 // doneExecer finishes something as soon as its run
 type DoneExecer struct {
 	State     execer.ProcessState
-	ExitCode  int
+	ExitCode  errors.ExitCode
 	ExecError error
 }
 

--- a/runner/execer/execers/sim.go
+++ b/runner/execer/execers/sim.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/twitter/scoot/common/errors"
 	"github.com/twitter/scoot/runner/execer"
 )
 
@@ -78,7 +79,7 @@ func (e *SimExecer) parseArg(arg string) (simStep, error) {
 			t := fmt.Errorf("error parsing <n> in complete <n>:%s", err.Error())
 			return nil, t
 		}
-		return &completeStep{i}, nil
+		return &completeStep{errors.ExitCode(i)}, nil
 	case "pause":
 		return &pauseStep{e.resumeCh}, nil
 	case "sleep":
@@ -153,7 +154,7 @@ type simStep interface {
 }
 
 type completeStep struct {
-	exitCode int
+	exitCode errors.ExitCode
 }
 
 func (s *completeStep) run(status execer.ProcessStatus, p *simProcess) execer.ProcessStatus {

--- a/runner/execer/execers/sim_test.go
+++ b/runner/execer/execers/sim_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/twitter/scoot/common/errors"
 	"github.com/twitter/scoot/runner/execer"
 )
 
@@ -67,7 +68,7 @@ func assertStatus(t *testing.T, expected execer.ProcessStatus, p execer.Process,
 	}
 }
 
-func complete(exitCode int) execer.ProcessStatus {
+func complete(exitCode errors.ExitCode) execer.ProcessStatus {
 	r := execer.ProcessStatus{}
 	r.State = execer.COMPLETE
 	r.ExitCode = exitCode

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	scoot_e "github.com/twitter/scoot/common/errors"
 	"github.com/twitter/scoot/common/log/tags"
 	"github.com/twitter/scoot/common/stats"
 	"github.com/twitter/scoot/runner/execer"
@@ -386,7 +387,7 @@ func (p *osProcess) Wait() (result execer.ProcessStatus) {
 		// we can get the commands exit code
 		if status, ok := err.Sys().(syscall.WaitStatus); ok {
 			result.State = execer.COMPLETE
-			result.ExitCode = status.ExitStatus()
+			result.ExitCode = scoot_e.ExitCode(status.ExitStatus())
 			// stdout and stderr are collected and set by (invoke.go) runner
 			return result
 		}
@@ -558,7 +559,7 @@ func (p *osProcess) KillAndWait(resultError string) {
 	_, err = p.cmd.Process.Wait()
 	if err, ok := err.(*exec.ExitError); ok {
 		if status, ok := err.Sys().(syscall.WaitStatus); ok {
-			p.result.ExitCode = status.ExitStatus()
+			p.result.ExitCode = scoot_e.ExitCode(status.ExitStatus())
 		}
 	}
 }

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"time"
 
-	scoot_e "github.com/twitter/scoot/common/errors"
+	scooterror "github.com/twitter/scoot/common/errors"
 	"github.com/twitter/scoot/common/log/tags"
 	"github.com/twitter/scoot/common/stats"
 	"github.com/twitter/scoot/runner/execer"
@@ -387,7 +387,7 @@ func (p *osProcess) Wait() (result execer.ProcessStatus) {
 		// we can get the commands exit code
 		if status, ok := err.Sys().(syscall.WaitStatus); ok {
 			result.State = execer.COMPLETE
-			result.ExitCode = scoot_e.ExitCode(status.ExitStatus())
+			result.ExitCode = scooterror.ExitCode(status.ExitStatus())
 			// stdout and stderr are collected and set by (invoke.go) runner
 			return result
 		}
@@ -559,7 +559,7 @@ func (p *osProcess) KillAndWait(resultError string) {
 	_, err = p.cmd.Process.Wait()
 	if err, ok := err.(*exec.ExitError); ok {
 		if status, ok := err.Sys().(syscall.WaitStatus); ok {
-			p.result.ExitCode = scoot_e.ExitCode(status.ExitStatus())
+			p.result.ExitCode = scooterror.ExitCode(status.ExitStatus())
 		}
 	}
 }

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -472,10 +472,7 @@ func (c *QueueController) runAndWatch(cmdID cmdAndID) chan runner.RunStatus {
 killForPersistentError returns true when one of the critical errors has occurred 2 times in a row.
 */
 func (c *QueueController) killForPersistenError(exitCode errors.ExitCode) bool {
-	if exitCode == c.lastExitCode &&
+	return exitCode == c.lastExitCode &&
 		(exitCode == errors.CleanFailureExitCode ||
-			exitCode == errors.CheckoutFailureExitCode) {
-		return true
-	}
-	return false
+			exitCode == errors.CheckoutFailureExitCode)
 }

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -456,9 +456,9 @@ func (c *QueueController) runAndWatch(cmdID cmdAndID) chan runner.RunStatus {
 			if st.State.IsDone() {
 				if st.ExitCode == int(c.lastExitCode) &&
 					(st.ExitCode == errors.CleanFailureExitCode ||
-					st.ExitCode == errors.CheckoutFailureExitCode ||
-					st.ExitCode == errors.GenericCheckoutFailureExitCode ||
-					st.ExitCode == errors.ReleaseCheckoutFailureExitCode) {
+						st.ExitCode == errors.CheckoutFailureExitCode ||
+						st.ExitCode == errors.GenericCheckoutFailureExitCode ||
+						st.ExitCode == errors.ReleaseCheckoutFailureExitCode) {
 					c.inv.stat.Counter(stats.WorkerServerKillGauge).Inc(1)
 					log.Fatalf("Multiple git-based errors (%d) in a row recorded. Killing worker.", st.ExitCode)
 				}

--- a/runner/runners/service_test.go
+++ b/runner/runners/service_test.go
@@ -20,7 +20,7 @@ func teardown(t *testing.T) {
 
 var t tags.LogTags
 
-func complete(exitCode int) runner.RunStatus {
+func complete(exitCode errors.ExitCode) runner.RunStatus {
 	return runner.CompleteStatus(runner.RunID(""), "", exitCode, t)
 }
 

--- a/runner/status.go
+++ b/runner/status.go
@@ -77,7 +77,7 @@ type RunStatus struct {
 	// Only valid if State == COMPLETE
 	SnapshotID string
 	// Only valid if State == (COMPLETE || FAILED)
-	ExitCode int
+	ExitCode errors.ExitCode
 	// Only valid if State == (COMPLETE || FAILED || ABORTED)
 	Error string
 	// Only valid if task is run on a Bazel filer
@@ -128,7 +128,7 @@ func FailedStatus(runID RunID, err *errors.ExitCodeError, tags tags.LogTags) (r 
 	r.RunID = runID
 	r.State = FAILED
 	r.Error = err.Error()
-	r.ExitCode = int(err.GetExitCode())
+	r.ExitCode = err.GetExitCode()
 	r.LogTags = tags
 	return r
 }
@@ -149,7 +149,7 @@ func RunningStatus(runID RunID, stdoutRef, stderrRef string, tags tags.LogTags) 
 	return r
 }
 
-func CompleteStatus(runID RunID, snapshotID string, exitCode int, tags tags.LogTags) (r RunStatus) {
+func CompleteStatus(runID RunID, snapshotID string, exitCode errors.ExitCode, tags tags.LogTags) (r RunStatus) {
 	r.RunID = runID
 	r.State = COMPLETE
 	r.SnapshotID = snapshotID

--- a/snapshot/git/gitdb/checkout.go
+++ b/snapshot/git/gitdb/checkout.go
@@ -147,12 +147,15 @@ func (db *DB) releaseCheckout(path string) error {
 	if exists := db.checkouts[path]; !exists {
 		return nil
 	}
+
 	err := os.RemoveAll(path)
 	if err == nil {
 		return nil
 	}
+
+	// TODO - this looks suspicious.... why don't we delete the path entry in db.checkouts when we've successfully removed that dir?
 	delete(db.checkouts, path)
-	return err
+	return errors.NewError(fmt.Errorf("Error:%v, Releasing checkout path: %v", err, path), errors.ReleaseCheckoutFailureCode)
 }
 
 func (db *DB) exportGitCommit(id snap.ID, externalRepo *repo.Repository) (string, error) {

--- a/snapshot/git/gitdb/checkout.go
+++ b/snapshot/git/gitdb/checkout.go
@@ -153,7 +153,9 @@ func (db *DB) releaseCheckout(path string) error {
 		return nil
 	}
 
-	// TODO - this looks suspicious.... why don't we delete the path entry in db.checkouts when we've successfully removed that dir?
+	// TODO - this looks suspicious....
+	// why don't we delete the path entry in db.checkouts when we've successfully removed that dir (in if statement
+	// up at ln 152)?
 	delete(db.checkouts, path)
 	return errors.NewError(fmt.Errorf("Error:%v, Releasing checkout path: %v", err, path), errors.ReleaseCheckoutFailureCode)
 }

--- a/snapshot/git/gitdb/db.go
+++ b/snapshot/git/gitdb/db.go
@@ -15,8 +15,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// TODO verify that we really use this code - is this only used by FSSnapshot?  Are we using FSSnapshot?
-
 // TODO The interfaces and functionality here should be refactored to only use git when necessary.
 // Many operations relying on git are more inefficient than they need to be:
 // we could be using memory buffers/streams instead of using git cmds on disk to transform data.

--- a/snapshot/git/gitdb/db.go
+++ b/snapshot/git/gitdb/db.go
@@ -15,6 +15,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// TODO verify that we really use this code - is this only used by FSSnapshot?  Are we using FSSnapshot?
+
 // TODO The interfaces and functionality here should be refactored to only use git when necessary.
 // Many operations relying on git are more inefficient than they need to be:
 // we could be using memory buffers/streams instead of using git cmds on disk to transform data.

--- a/workerapi/api.go
+++ b/workerapi/api.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/twitter/scoot/bazel/execution/bazelapi"
+	"github.com/twitter/scoot/common/errors"
 	"github.com/twitter/scoot/common/log/helpers"
 	"github.com/twitter/scoot/common/log/tags"
 	"github.com/twitter/scoot/common/thrifthelpers"
@@ -133,7 +134,7 @@ func ThriftRunStatusToDomain(thrift *worker.RunStatus) runner.RunStatus {
 		domain.Error = *thrift.Error
 	}
 	if thrift.ExitCode != nil {
-		domain.ExitCode = int(*thrift.ExitCode)
+		domain.ExitCode = errors.ExitCode(*thrift.ExitCode)
 	}
 	if thrift.SnapshotId != nil {
 		domain.SnapshotID = *thrift.SnapshotId

--- a/workerapi/api_test.go
+++ b/workerapi/api_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/twitter/scoot/common/errors"
 	"github.com/twitter/scoot/common/log/tags"
 	"github.com/twitter/scoot/runner"
 	"github.com/twitter/scoot/workerapi/gen-go/worker"
@@ -332,7 +333,7 @@ var tests = []struct {
 					State:     runner.PENDING,
 					StdoutRef: nonemptystr,
 					StderrRef: nonemptystr,
-					ExitCode:  int(nonzero),
+					ExitCode:  errors.ExitCode(int(nonzero)),
 					Error:     nonemptystr,
 				},
 			},


### PR DESCRIPTION
We had an incident where the worker had a stuck git index.lock file which was causing the worker to fail all tests.  We expanded the fail worker logic to include any repeated git error.

Does this include too many failure types?  Are there more that should be included?