### PR TITLE
saga - use mutex in Saga to guard against closed channel panic

### DIFF
--- a/saga/saga_test.go
+++ b/saga/saga_test.go
@@ -294,7 +294,7 @@ func TestEndCompTaskLogError(t *testing.T) {
 	}
 }
 
-func TestMessageAfterEndSagaPanics(t *testing.T) {
+func TestMessageAfterEndSagaDoesntPanic(t *testing.T) {
 	entry := MakeEndSagaMessage("testSaga")
 
 	mockCtrl := gomock.NewController(t)
@@ -307,13 +307,7 @@ func TestMessageAfterEndSagaPanics(t *testing.T) {
 	s, _ := newSaga("testSaga", nil, sagaLogMock)
 	_ = s.EndSaga()
 
-	defer func() {
-		if r := recover(); r != nil {
-		}
-	}()
 	s.StartTask("task1", nil)
-
-	t.Errorf("Expected sneding a message after edning a Saga to panic")
 }
 
 func TestFatalError_InvalidSagaState(t *testing.T) {

--- a/scheduler/server/stateful_scheduler.go
+++ b/scheduler/server/stateful_scheduler.go
@@ -1147,9 +1147,11 @@ func (s *statefulScheduler) processKillJobRequests(reqs []jobKillRequest) {
 			}
 		}
 
-		if err := jobState.Saga.BulkMessage(updateMessages); err != nil {
-			logFields["err"] = err
-			log.WithFields(logFields).Error("killJobs saga.BulkMessage failure")
+		if len(updateMessages) > 0 {
+			if err := jobState.Saga.BulkMessage(updateMessages); err != nil {
+				logFields["err"] = err
+				log.WithFields(logFields).Error("killJobs saga.BulkMessage failure")
+			}
 		}
 
 		delete(logFields, "err")

--- a/scheduler/server/stateful_scheduler_test.go
+++ b/scheduler/server/stateful_scheduler_test.go
@@ -605,12 +605,17 @@ func TestUpdateAvgDuration(t *testing.T) {
 	}
 }
 
+// Respectable figures from a 2018 13" Macbook Pro 2.7Ghz Quad core i7:
+// tasksInJob = 100:   181 iterations, ~6,000,000 ns/op
+// tasksInJob = 1000:  50  iterations, ~22,000,000 ns/op
+// tasksInJob = 10000: 4   iterations, ~300,000,000 ns/op
 func BenchmarkProcessKillJobsRequests(b *testing.B) {
 	sc := sagalogs.MakeInMemorySagaCoordinatorNoGC()
 	s, _, _ := initializeServices(sc, false)
+	tasksInJob := 10000
 
 	for i := 0; i < b.N; i++ {
-		jobId, _, _ := putJobInScheduler(10000, s, "pause", "", domain.P0)
+		jobId, _, _ := putJobInScheduler(tasksInJob, s, "pause", "", domain.P0)
 		s.step()
 
 		validKillRequests := []jobKillRequest{{jobId: jobId, responseCh: make(chan error, 1)}}


### PR DESCRIPTION
Because EndSaga logs are async it is possible to attempt to log messages after the EndSaga has been logged (EndSaga closes the saga update channel). Additionally, there is nothing in the saga.Saga API preventing this usage.

Short of redesigning Saga usage and implementation, this should prevent this type of usage from crashing the scheduler. It is likely that cases where messages sent on ended sagas could be considered benign errors due to the existing scheduler design.