### PR TITLE
fixed panic error when adding a worker to "" groups idle list

### DIFF
--- a/scheduler/server/task_scheduler_test.go
+++ b/scheduler/server/task_scheduler_test.go
@@ -67,8 +67,6 @@ func Test_TaskAssignments_TasksScheduled(t *testing.T) {
 }
 
 func Test_TaskAssignment_Affinity(t *testing.T) {
-	// testCluster := makeTestCluster("node1", "node2", "node3")
-	// s := getDebugStatefulScheduler(testCluster)
 	sc := sagalogs.MakeInMemorySagaCoordinatorNoGC()
 	s, _, _ := initializeServices(sc, false)
 	cs := s.clusterState
@@ -109,6 +107,9 @@ func Test_TaskAssignment_Affinity(t *testing.T) {
 		t.Errorf("Expected 5 tasks to be assigned, got %v", len(assignments1))
 	}
 
+	_, ok := cs.nodeGroups[""]
+	assert.True(t, ok, "didn't find '' nodeGroup")
+
 	// complete one task from each job.
 	taskNodes := map[string]cluster.NodeId{}
 	completedTasksByJob := map[string]string{}
@@ -144,6 +145,8 @@ func Test_TaskAssignment_Affinity(t *testing.T) {
 	}
 
 	assert.True(t, haveNodeMatch)
+	_, ok = cs.nodeGroups[""]
+	assert.True(t, ok, "didn't find '' nodeGroup")
 }
 
 func getDebugStatefulScheduler(tc *testCluster) *statefulScheduler {


### PR DESCRIPTION
scheduler update introduced a panic at ln 273 in scheduler/server/cluster_state.go
**panic root cause:**
The panic was triggered by the following scenario:
-  all workers were allocated to non-"" groupIDs (snapshotID)
- task_scheduler would delete the "" group in cluster_state since there were no workers in that group
- then a worker was lost and re-added to the cluster before cluster_state recognized the worker as suspended
- cluster_state would try to add the worker to the "" group assuming the "" group existed. (ln 273 cluster_state.go)

**summary of the fix**
- The change updates task_scheduler to use a local copy of the node groups and does not update cluster_state's nodeGroups
- The old code also updated cluster_states's nodeGroups directly in the assign() function, then tried to do the same update in cluster_state.taskScheduled() function.  (the second update would be a nop.)
- the unit test was updated to verify that the "" node group exists in cluster state after task assignment

**validation**
I recreated the panic in my devel instance then verified that I could not recreate the panic with this update deployed.
