### PR TITLE
endpoints - no default /health endpoint

### DIFF
--- a/common/endpoints/endpoints.go
+++ b/common/endpoints/endpoints.go
@@ -53,7 +53,7 @@ func (s *TwitterServer) Serve() error {
 }
 
 func helpHandler(w http.ResponseWriter, r *http.Request) {
-	msg := "Common paths: '/admin/metrics.json', '/output', '/debug/pprof'"
+	msg := "Common paths: '/admin/metrics.json', '/debug/pprof'"
 	http.Error(w, msg, http.StatusNotImplemented)
 }
 

--- a/common/endpoints/endpoints.go
+++ b/common/endpoints/endpoints.go
@@ -4,7 +4,6 @@ package endpoints
 
 import (
 	"bytes"
-	"fmt"
 	log "github.com/sirupsen/logrus"
 	"io"
 	"net/http"
@@ -25,7 +24,6 @@ func NewTwitterServer(addr Addr, stats stats.StatsReceiver, handlers map[string]
 	}
 }
 
-// TODO(dbentley): rename to ObservableServer(?)
 // A stats receiver that provides HTTP access for metric scraping with
 // Twitter-style endpoints.
 type TwitterServer struct {
@@ -37,7 +35,6 @@ type TwitterServer struct {
 func (s *TwitterServer) Serve() error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", helpHandler)
-	mux.HandleFunc("/health", healthHandler)
 	mux.HandleFunc("/admin/metrics.json", s.statsHandler)
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
 	mux.HandleFunc("/debug/pprof/cmdline", pprof.Index)
@@ -56,12 +53,8 @@ func (s *TwitterServer) Serve() error {
 }
 
 func helpHandler(w http.ResponseWriter, r *http.Request) {
-	msg := "Common paths: '/health', '/admin/metrics.json', '/output', '/debug/pprof'"
+	msg := "Common paths: '/admin/metrics.json', '/output', '/debug/pprof'"
 	http.Error(w, msg, http.StatusNotImplemented)
-}
-
-func healthHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "ok")
 }
 
 func (s *TwitterServer) statsHandler(w http.ResponseWriter, r *http.Request) {

--- a/common/endpoints/setup.go
+++ b/common/endpoints/setup.go
@@ -29,7 +29,6 @@ func (m module) Install(b *ice.MagicBag) {
 		},
 		NewTwitterServer,
 	)
-
 }
 
 // Starts the Server based on the MagicBag and config schema provided

--- a/workerapi/server/server_test.go
+++ b/workerapi/server/server_test.go
@@ -25,7 +25,6 @@ Test the stats collected by the server's stats() goroutine:
 */
 // TODO DISABLED TEST - time.Sleep based tests have data races and need to be refactored
 /*func TestInitStats(t *testing.T) {
-
 	//setup the test environment
 	// create a worker - (starting the init activity)
 	h, initDoneCh, statsRegistry, simExecer := setupTestEnv(false)
@@ -130,7 +129,6 @@ Test the stats collected by the server's stats() goroutine:
 }*/
 
 func setupTestEnv(useErrorExec bool) (h *handler, initDoneCh chan error, statsRegistry stats.StatsRegistry, simExecer *execers.SimExecer) {
-
 	stats.StatReportIntvl = 100 * time.Millisecond
 	log.AddHook(hooks.NewContextHook())
 
@@ -208,7 +206,6 @@ func setupTestEnv(useErrorExec bool) (h *handler, initDoneCh chan error, statsRe
 	h = w.(*handler)
 
 	return
-
 }
 
 // ************************ fake objects for tests:  (do we already have these somewhere?)


### PR DESCRIPTION
Don't add a default handler that is only needed on aurora. Will be replaced internally.