### PR TITLE
additional logging and stats

### DIFF
--- a/async/mailbox.go
+++ b/async/mailbox.go
@@ -122,7 +122,7 @@ func (bx *Mailbox) ProcessMessages() {
 			unCompletedMsgs = append(unCompletedMsgs, msg)
 		}
 	}
-	log.Infof("processed (worker) messages in %v", time.Since(start))
+	log.Infof("processed %d (worker) messages in %v", len(bx.msgs), time.Since(start))
 
 	// reset inProgress messages to unCompletedMsgs only
 	bx.msgs = unCompletedMsgs

--- a/async/mailbox.go
+++ b/async/mailbox.go
@@ -1,5 +1,11 @@
 package async
 
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
 // An AsyncMailbox stores AsyncErrors and their associated callbacks
 // and invokes them once the AsyncError is completed
 //
@@ -105,6 +111,7 @@ func (bx *Mailbox) NewAsyncError(cb AsyncErrorResponseHandler) *AsyncError {
 // the callback function and removes the message from the mailbox
 func (bx *Mailbox) ProcessMessages() {
 	var unCompletedMsgs []message
+	start := time.Now()
 	for _, msg := range bx.msgs {
 		ok, err := msg.Err.TryGetValue()
 
@@ -115,6 +122,7 @@ func (bx *Mailbox) ProcessMessages() {
 			unCompletedMsgs = append(unCompletedMsgs, msg)
 		}
 	}
+	log.Infof("processed (worker) messages in %v", time.Since(start))
 
 	// reset inProgress messages to unCompletedMsgs only
 	bx.msgs = unCompletedMsgs

--- a/bazel/execution/service.go
+++ b/bazel/execution/service.go
@@ -280,7 +280,7 @@ func (s *executionServer) CancelOperation(_ context.Context, req *longrunning.Ca
 // Internal functions
 
 func (s *executionServer) getRunStatusAndValidate(jobID string) (*runStatus, error) {
-	js, err := thrift.GetJobStatus(jobID, s.sagaCoord)
+	js, err := thrift.GetJobStatus(jobID, s.sagaCoord, s.stat)
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +300,7 @@ func (s *executionServer) getRunStatusAndValidate(jobID string) (*runStatus, err
 }
 
 func (s *executionServer) killJobAndValidate(jobID string) error {
-	js, err := thrift.KillJob(jobID, s.scheduler, s.sagaCoord)
+	js, err := thrift.KillJob(jobID, s.scheduler, s.sagaCoord, s.stat)
 	if err != nil {
 		return err
 	}

--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -150,7 +150,18 @@ const (
 	/*
 		the number of times the processing failed to serialize the workerapi status object
 	*/
+
 	SchedFailedTaskSerializeCounter = "failedTaskSerializeCounter"
+	/*
+		the time (sec) to get the job's status structure from sagalog
+	*/
+
+	SchedGetJobStatusSagaLatencySec = "schedGetStatusSagaGaugeSec"
+	/*
+		the time (sec) to convert the sagalog structure to the return structure
+	*/
+	SchedGetJobStatusConversionLatencySec = "schedGetStatusConversionGaugeSec"
+
 	/*
 		The number of tasks from the inProgress list waiting to start or running.
 	*/

--- a/scheduler/api/server.go
+++ b/scheduler/api/server.go
@@ -52,14 +52,14 @@ func (h *Handler) RunJob(def *scoot.JobDefinition) (*scoot.JobId, error) {
 func (h *Handler) GetStatus(jobId string) (*scoot.JobStatus, error) {
 	defer h.stat.Latency(stats.SchedServerJobStatusLatency_ms).Time().Stop()
 	h.stat.Counter(stats.SchedServerJobStatusCounter).Inc(1)
-	return schedthrift.GetJobStatus(jobId, h.sagaCoord)
+	return schedthrift.GetJobStatus(jobId, h.sagaCoord, h.stat)
 }
 
 // Implements KillJob Cloud Scoot API
 func (h *Handler) KillJob(jobId string) (*scoot.JobStatus, error) {
 	defer h.stat.Latency(stats.SchedServerJobKillLatency_ms).Time().Stop()
 	h.stat.Counter(stats.SchedServerJobKillCounter).Inc(1)
-	return schedthrift.KillJob(jobId, h.scheduler, h.sagaCoord)
+	return schedthrift.KillJob(jobId, h.scheduler, h.sagaCoord, h.stat)
 }
 
 // Implements OfflineWorker Cloud Scoot API

--- a/scheduler/api/thrift/get_status.go
+++ b/scheduler/api/thrift/get_status.go
@@ -47,14 +47,14 @@ func GetJobStatus(jobId string, sc s.SagaCoordinator, stat stats.StatsReceiver) 
 	}
 
 	start = time.Now()
-	scootJs := convertSagaStateToJobStatus(state)
+	js := convertSagaStateToJobStatus(state)
 
 	// log and record stats
 	convertDur := time.Since(start)
-	log.Infof("GetJobStatus took %v (%v in GetSagaState, %v in convertSagaState), for job: %s", getSagaStateDur+convertDur, getSagaStateDur, convertDur, jobId)
+	log.Infof("GetJobStatus took %v (%v in GetSagaState, %v in convertSagaStßate), for job: %s", getSagaStateDur+convertDur, getSagaStateDur, convertDur, jobId)
 	stat.Gauge(stats.SchedGetJobStatusConversionLatencySec).Update(int64(convertDur.Seconds()))
 
-	return scootJs, nil
+	return js, nil
 }
 
 // Converts a SagaState to a corresponding JobStatus

--- a/scheduler/api/thrift/get_status_test.go
+++ b/scheduler/api/thrift/get_status_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
+	"github.com/twitter/scoot/common/stats"
 	"github.com/twitter/scoot/common/thrifthelpers"
 	"github.com/twitter/scoot/runner"
 	s "github.com/twitter/scoot/saga"
@@ -23,7 +24,7 @@ func Test_GetJobStatus_InternalLogError(t *testing.T) {
 	sagaLogMock.EXPECT().GetMessages("job1").Return(nil, s.NewInternalLogError("test error"))
 	sagaCoord := s.MakeSagaCoordinator(sagaLogMock)
 
-	status, err := GetJobStatus("job1", sagaCoord)
+	status, err := GetJobStatus("job1", sagaCoord, stats.NilStatsReceiver())
 	if err == nil {
 		t.Error("Expected error to be returned when SagaLog fails to retrieve messages")
 	}
@@ -47,7 +48,7 @@ func Test_GetJobStatus_InvalidRequestError(t *testing.T) {
 	sagaLogMock.EXPECT().GetMessages("job1").Return(nil, s.NewInvalidRequestError("test error"))
 	sagaCoord := s.MakeSagaCoordinator(sagaLogMock)
 
-	status, err := GetJobStatus("job1", sagaCoord)
+	status, err := GetJobStatus("job1", sagaCoord, stats.NilStatsReceiver())
 	if err == nil {
 		t.Error("Expected error to be returned when SagaLog fails to retrieve messages")
 	}
@@ -71,7 +72,7 @@ func Test_GetJobStatus_NoSagaMessages(t *testing.T) {
 	sagaLogMock.EXPECT().GetMessages("job1").Return(nil, nil)
 	sagaCoord := s.MakeSagaCoordinator(sagaLogMock)
 
-	status, err := GetJobStatus("job1", sagaCoord)
+	status, err := GetJobStatus("job1", sagaCoord, stats.NilStatsReceiver())
 	if err != nil {
 		t.Error("Unexpected error returned", err)
 	}
@@ -215,7 +216,7 @@ func TestRunStatusRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	jobStatus, err := GetJobStatus(jobID, sagaCoord)
+	jobStatus, err := GetJobStatus(jobID, sagaCoord, stats.NilStatsReceiver())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scheduler/api/thrift/kill_job.go
+++ b/scheduler/api/thrift/kill_job.go
@@ -1,6 +1,7 @@
 package thrift
 
 import (
+	"github.com/twitter/scoot/common/stats"
 	"github.com/twitter/scoot/saga"
 	"github.com/twitter/scoot/scheduler/api/thrift/gen-go/scoot"
 	"github.com/twitter/scoot/scheduler/server"
@@ -11,11 +12,11 @@ Kill the job identified by jobId.  Update the saga for the job to indicate
 that it was killed.  Return a job status indicating that the job was successfully
 killed or one of the following errors
 */
-func KillJob(jobId string, scheduler server.Scheduler, sc saga.SagaCoordinator) (*scoot.JobStatus, error) {
+func KillJob(jobId string, scheduler server.Scheduler, sc saga.SagaCoordinator, stat stats.StatsReceiver) (*scoot.JobStatus, error) {
 	err := scheduler.KillJob(jobId)
 	if err != nil {
 		return nil, err
 	}
 
-	return GetJobStatus(jobId, sc)
+	return GetJobStatus(jobId, sc, stat)
 }

--- a/scheduler/api/thrift/kill_job_test.go
+++ b/scheduler/api/thrift/kill_job_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 
+	"github.com/twitter/scoot/common/stats"
 	"github.com/twitter/scoot/saga"
 	"github.com/twitter/scoot/scheduler/api/thrift/gen-go/scoot"
 	"github.com/twitter/scoot/scheduler/server"
@@ -25,13 +26,13 @@ func Test_KillJob(t *testing.T) {
 	s := makeMockScheduler(t)
 
 	// test scheduler.KillJob returning a non-null error
-	_, err := KillJob("err", s, sc)
+	_, err := KillJob("err", s, sc, stats.NilStatsReceiver())
 	if err == nil {
 		t.Fatal("Expected error insted got nil")
 	}
 
 	// test scheduler.KillJob not finding an error and KillJob calling GetJobStatus
-	st, err := KillJob("1", s, sc)
+	st, err := KillJob("1", s, sc, stats.NilStatsReceiver())
 	if err != nil {
 		t.Fatalf("Expected error to be nil, instead got %s", err.Error())
 	}


### PR DESCRIPTION
we are seeing instances where a worker completes a task, but it takes a long time (over 20 minutes) for the scheduler to assign the worker a new task.  We are also seeing 10 minute timeout errors getting a job's status.

Added:
logging the time it takes to loop through all active tasks looking for completed tasks (in mailbox.go) and 
stats and logging for time it takes to build a job's status response.

