### PR TITLE
fix create jobState, order tasks by average duration (desc)

### DIFF
--- a/scheduler/server/job_state.go
+++ b/scheduler/server/job_state.go
@@ -88,8 +88,7 @@ func newJobState(job *domain.Job, jobClass string, saga *saga.Saga, taskDuration
 
 	for _, taskDef := range job.Def.Tasks {
 		var duration time.Duration
-		origKey := taskDef.TaskID
-		durationKey := durationKeyExtractor(origKey)
+		durationKey := durationKeyExtractor(taskDef.TaskID)
 		if taskDurations != nil {
 			if iface, ok := taskDurations.Get(durationKey); !ok {
 				duration = math.MaxInt64

--- a/scheduler/server/job_state_test.go
+++ b/scheduler/server/job_state_test.go
@@ -13,7 +13,7 @@ func Test_GetUnscheduledTasks_ReturnsAllUnscheduledTasks(t *testing.T) {
 	jobAsBytes, _ := job.Serialize()
 
 	saga, _ := sagalogs.MakeInMemorySagaCoordinatorNoGC().MakeSaga(job.Id, jobAsBytes)
-	jobState := newJobState(&job, "", saga, nil, nil)
+	jobState := newJobState(&job, "", saga, nil, nil, defaultDurationKeyExtractor)
 
 	tasks := jobState.getUnScheduledTasks()
 
@@ -31,7 +31,7 @@ func Test_NewJobState_PreviousProgress_StartedTasks(t *testing.T) {
 	for _, task := range job.Def.Tasks {
 		saga.StartTask(task.TaskID, nil)
 	}
-	jobState := newJobState(&job, "", saga, nil, nil)
+	jobState := newJobState(&job, "", saga, nil, nil, defaultDurationKeyExtractor)
 
 	tasks := jobState.getUnScheduledTasks()
 	if len(tasks) != len(job.Def.Tasks) {
@@ -49,7 +49,7 @@ func Test_NewJobState_PreviousProgress_CompletedTasks(t *testing.T) {
 		saga.StartTask(task.TaskID, nil)
 		saga.EndTask(task.TaskID, nil)
 	}
-	jobState := newJobState(&job, "", saga, nil, nil)
+	jobState := newJobState(&job, "", saga, nil, nil, defaultDurationKeyExtractor)
 
 	tasks := jobState.getUnScheduledTasks()
 	if len(tasks) != 0 {

--- a/scheduler/server/job_state_test.go
+++ b/scheduler/server/job_state_test.go
@@ -13,7 +13,7 @@ func Test_GetUnscheduledTasks_ReturnsAllUnscheduledTasks(t *testing.T) {
 	jobAsBytes, _ := job.Serialize()
 
 	saga, _ := sagalogs.MakeInMemorySagaCoordinatorNoGC().MakeSaga(job.Id, jobAsBytes)
-	jobState := newJobState(&job, "", saga, nil, nil, defaultDurationKeyExtractor)
+	jobState := newJobState(&job, "", saga, nil, nil, nopDurationKeyExtractor)
 
 	tasks := jobState.getUnScheduledTasks()
 
@@ -31,7 +31,7 @@ func Test_NewJobState_PreviousProgress_StartedTasks(t *testing.T) {
 	for _, task := range job.Def.Tasks {
 		saga.StartTask(task.TaskID, nil)
 	}
-	jobState := newJobState(&job, "", saga, nil, nil, defaultDurationKeyExtractor)
+	jobState := newJobState(&job, "", saga, nil, nil, nopDurationKeyExtractor)
 
 	tasks := jobState.getUnScheduledTasks()
 	if len(tasks) != len(job.Def.Tasks) {
@@ -49,7 +49,7 @@ func Test_NewJobState_PreviousProgress_CompletedTasks(t *testing.T) {
 		saga.StartTask(task.TaskID, nil)
 		saga.EndTask(task.TaskID, nil)
 	}
-	jobState := newJobState(&job, "", saga, nil, nil, defaultDurationKeyExtractor)
+	jobState := newJobState(&job, "", saga, nil, nil, nopDurationKeyExtractor)
 
 	tasks := jobState.getUnScheduledTasks()
 	if len(tasks) != 0 {

--- a/scheduler/server/stateful_scheduler.go
+++ b/scheduler/server/stateful_scheduler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -1292,6 +1293,7 @@ func addOrUpdateTaskDuration(taskDurations *lru.Cache, durationKey string, d tim
 	} else {
 		ad, ok = iface.(*averageDuration)
 		if !ok {
+			log.Errorf("task duration object was not *averageDuration type!  (it is %s)", reflect.TypeOf(ad))
 			return
 		}
 		ad.update(d)

--- a/scheduler/server/stateful_scheduler.go
+++ b/scheduler/server/stateful_scheduler.go
@@ -89,8 +89,8 @@ func stringInSlice(a string, list []string) bool {
 	return false
 }
 
-// defaultDurationKeyExtractor returns an unchanged key.
-func defaultDurationKeyExtractor(key string) string {
+// nopDurationKeyExtractor returns an unchanged key.
+func nopDurationKeyExtractor(key string) string {
 	return key
 }
 
@@ -313,7 +313,7 @@ func NewStatefulScheduler(
 
 	dkef := durationKeyExtractorFn
 	if durationKeyExtractorFn == nil {
-		dkef = defaultDurationKeyExtractor
+		dkef = nopDurationKeyExtractor
 	}
 
 	sched := &statefulScheduler{

--- a/scheduler/server/task_scheduler_test.go
+++ b/scheduler/server/task_scheduler_test.go
@@ -19,7 +19,7 @@ func Test_TaskAssignment_NoNodesAvailable(t *testing.T) {
 	jobAsBytes, _ := job.Serialize()
 
 	saga, _ := sagalogs.MakeInMemorySagaCoordinatorNoGC().MakeSaga(job.Id, jobAsBytes)
-	js := newJobState(&job, "", saga, nil, nil, defaultDurationKeyExtractor)
+	js := newJobState(&job, "", saga, nil, nil, nopDurationKeyExtractor)
 
 	// create a test cluster with no nodes
 	testCluster := makeTestCluster()
@@ -49,7 +49,7 @@ func Test_TaskAssignments_TasksScheduled(t *testing.T) {
 	jobAsBytes, _ := job.Serialize()
 
 	saga, _ := sagalogs.MakeInMemorySagaCoordinatorNoGC().MakeSaga(job.Id, jobAsBytes)
-	js := newJobState(&job, "", saga, nil, nil, defaultDurationKeyExtractor)
+	js := newJobState(&job, "", saga, nil, nil, nopDurationKeyExtractor)
 
 	// create a test cluster with 5 nodes
 	testCluster := makeTestCluster("node1", "node2", "node3", "node4", "node5")

--- a/scheduler/server/task_scheduler_test.go
+++ b/scheduler/server/task_scheduler_test.go
@@ -19,7 +19,7 @@ func Test_TaskAssignment_NoNodesAvailable(t *testing.T) {
 	jobAsBytes, _ := job.Serialize()
 
 	saga, _ := sagalogs.MakeInMemorySagaCoordinatorNoGC().MakeSaga(job.Id, jobAsBytes)
-	js := newJobState(&job, "", saga, nil, nil)
+	js := newJobState(&job, "", saga, nil, nil, defaultDurationKeyExtractor)
 
 	// create a test cluster with no nodes
 	testCluster := makeTestCluster()
@@ -32,7 +32,7 @@ func Test_TaskAssignment_NoNodesAvailable(t *testing.T) {
 }
 
 func Test_TaskAssignment_NoTasks(t *testing.T) {
-	// create a test cluster with no nodes
+	// create a test cluster with 5 nodes
 	testCluster := makeTestCluster("node1", "node2", "node3", "node4", "node5")
 	s := getDebugStatefulScheduler(testCluster)
 	assignments := getTaskAssignments([]*jobState{}, s)
@@ -49,9 +49,9 @@ func Test_TaskAssignments_TasksScheduled(t *testing.T) {
 	jobAsBytes, _ := job.Serialize()
 
 	saga, _ := sagalogs.MakeInMemorySagaCoordinatorNoGC().MakeSaga(job.Id, jobAsBytes)
-	js := newJobState(&job, "", saga, nil, nil)
+	js := newJobState(&job, "", saga, nil, nil, defaultDurationKeyExtractor)
 
-	// create a test cluster with no nodes
+	// create a test cluster with 5 nodes
 	testCluster := makeTestCluster("node1", "node2", "node3", "node4", "node5")
 	s := getDebugStatefulScheduler(testCluster)
 	unScheduledTasks := js.getUnScheduledTasks()


### PR DESCRIPTION
- newJobState() uses task duration key extractor function when setting a new task's average duration

- addOrUpdateTaskDuration() only add when the task's key is not in the lru cache, otherwise update the current lru cache entry.