### PR TITLE
revert pr 521's task runner result state change

### DIFF
--- a/scheduler/server/task_runner.go
+++ b/scheduler/server/task_runner.go
@@ -107,6 +107,7 @@ func (r *taskRunner) run() error {
 
 	// Update taskErr's Error to indicate we got an empty status back
 	if taskErr.st.State == runner.UNKNOWN {
+		taskErr.st.State = runner.FAILED
 		taskErr.st.Error = emptyStatusError(r.JobID, r.TaskID, err)
 	}
 	if shouldDeadLetter {

--- a/scheduler/server/task_runner_test.go
+++ b/scheduler/server/task_runner_test.go
@@ -11,6 +11,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
+	"io/ioutil"
+
 	"github.com/twitter/scoot/cloud/cluster"
 	"github.com/twitter/scoot/common/log/hooks"
 	"github.com/twitter/scoot/common/log/tags"
@@ -22,7 +24,6 @@ import (
 	"github.com/twitter/scoot/scheduler/domain"
 	"github.com/twitter/scoot/scheduler/setup/worker"
 	"github.com/twitter/scoot/workerapi"
-	"io/ioutil"
 )
 
 var tmp string
@@ -228,7 +229,7 @@ func Test_cannotGetStatusFromWorkerReturnsFlakyResult(t *testing.T) {
 	err := get_testTaskRunner(s, chaos, "job1", "task1", task, true, stats.NilStatsReceiver()).run()
 
 	assert.NotNil(t, err.(*taskError).runnerErr)
-	assert.Equal(t, err.(*taskError).st.State, runner.UNKNOWN)
+	assert.Equal(t, err.(*taskError).st.State, runner.FAILED)
 	assert.Equal(t, fmt.Sprintf("%s", err.(*taskError).runnerErr), "connection error")
 }
 


### PR DESCRIPTION
we can't have scheduler marking batches of workers as suspended when we are restarting a batch of 1000 workers.  We need to rethink what to do with 'lost' workers in this situation.