### PR TITLE
Don't return failed status on ingestion failure

### DIFF
--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -489,10 +489,15 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 			case res := <-ingestCh:
 				switch res.(type) {
 				case error:
-					return runner.FailedStatus(id, errors.NewError(fmt.Errorf("error ingesting results: %v", res), errors.PostExecFailureExitCode),
-						tags.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID, Tag: cmd.Tag})
+					log.WithFields(
+						log.Fields{
+							"tag":    cmd.Tag,
+							"jobID":  cmd.JobID,
+							"taskID": cmd.TaskID,
+						}).Errorf("Error ingesting results: %v", res)
+				default:
+					snapshotID = res.(string)
 				}
-				snapshotID = res.(string)
 			}
 			rts.outputEnd = stamp()
 			rts.invokeEnd = stamp()


### PR DESCRIPTION
This can happen due to external failures. We still have a reference to the log files on the worker instance, and know the exit code of the task. We can just log the error and return that exit code.