### PR TITLE
re-checkout even if we're already on the correct branch

### DIFF
--- a/snapshot/git/gitdb/checkout.go
+++ b/snapshot/git/gitdb/checkout.go
@@ -68,18 +68,7 @@ func (db *DB) checkout(id snap.ID) (path string, err error) {
 		// For FSSnapshots, we make a "bare checkout".
 		return db.checkoutFSSnapshot(v.SHA())
 	case KindGitCommitSnapshot:
-		// For GitCommitSnapshot's, we use dataRepo's work tree.
-		if id == db.currentSnapID {
-			log.Infof("Using cached checkout for id=%s", id)
-			return db.dataRepo.Dir(), nil
-		}
-		path, err := db.checkoutGitCommitSnapshot(v.SHA())
-		if err != nil {
-			db.currentSnapID = ""
-		} else {
-			db.currentSnapID = id
-		}
-		return path, err
+		return db.checkoutGitCommitSnapshot(v.SHA())
 	default:
 		return "", fmt.Errorf("cannot checkout value kind %v; id %v", v.Kind(), v.ID())
 	}

--- a/snapshot/git/gitdb/db.go
+++ b/snapshot/git/gitdb/db.go
@@ -125,9 +125,6 @@ type DB struct {
 	bundles    *bundlestoreBackend
 	autoUpload uploader // This is one of our backends that we use to upload automatically
 
-	// TODO: reusing git checkout if its snap.ID matches the request - make this configurable at runtime...
-	currentSnapID snap.ID
-
 	stat stats.StatsReceiver
 }
 


### PR DESCRIPTION
This fixes a bug where if a snapshot is currently checked out on a worker & the worker receives a new task with the same snapshot, we immediately run the task without modification to the working directory. This is an issue if the previous task has modified the working state at all, and can lead to inconsistent results.