### PR TITLE
Changing exec command so stderr is populated on deletion errors

### DIFF
--- a/cleaner/dirconfig/entire_dir_config.go
+++ b/cleaner/dirconfig/entire_dir_config.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 
 	log "github.com/sirupsen/logrus"
-
 	"github.com/twitter/scoot/common/stats"
 )
 
@@ -39,7 +38,7 @@ func (dc EntireDirConfig) cleanDir() error {
 	args := []string{"-rf", dc.GetDir()}
 
 	log.Infof("Running cleanup for %s with cmd: %s %s\n", dc.GetDir(), name, args)
-	err := exec.Command(name, args...).Run()
+	_, err := exec.Command(name, args...).Output()
 	if err != nil {
 		log.Errorf("Error running cleanup command (this can commonly fail due to non-empty directories): %s\n", err)
 		if errExit, ok := err.(*exec.ExitError); ok {

--- a/cleaner/dirconfig/last_accessed_dir_config.go
+++ b/cleaner/dirconfig/last_accessed_dir_config.go
@@ -70,7 +70,7 @@ func (dc lastAccessedDirConfig) cleanDir(retentionMin uint) error {
 	args := []string{dc.GetDir(), "!", "-path", dc.GetDir(), "-amin", fmt.Sprintf("+%d", retentionMin), "-delete"}
 
 	log.Infof("Running cleanup for %s with cmd: %s %s\n", dc.GetDir(), name, args)
-	err := exec.Command(name, args...).Run()
+	_, err := exec.Command(name, args...).Output()
 	if err != nil {
 		log.Errorf("Error running cleanup command (this can commonly fail due to non-empty directories): %s\n", err)
 		if errExit, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
Changed run() command to output() which copies stderr to the returned ExitError.