### PR TITLE
Added interface for log uploading by workers, replacing ingesting bundles

### DIFF
--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -486,13 +486,28 @@ const (
 	WorkerTimeSinceLastContactGauge_ms = "timeSinceLastContactGauge_ms"
 
 	/*
-		the number of times the worker uploaded a snapshot to bundlestore
+		the number of times the worker uploaded a log to storage
 	*/
 	WorkerUploads = "workerUploads"
 
 	/*
-		the amount of time spent uploading snapshots to bundlestore.  This includes time for
+		the number of times the worker log upload timed out
+	*/
+	WorkerLogUploadTimeouts = "workerLogUploadTimeouts"
+
+	/*
+		the number of times the worker log upload was retried
+	*/
+	WorkerLogUploadRetries = "workerLogUploadRetries"
+
+	/*
+		the amount of time spent uploading the log to storage. This includes time for
 		successful as well as erroring uploads
+	*/
+	WorkerLogUploadLatency_ms = "workerLogUploadLatency_ms"
+
+	/*
+		the overall time spent uploading logs(stderr, stdout & stdlog)
 	*/
 	WorkerUploadLatency_ms = "workerUploadLatency_ms"
 

--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -491,6 +491,11 @@ const (
 	WorkerUploads = "workerUploads"
 
 	/*
+		the number of times the worker log upload failed
+	*/
+	WorkerLogUploadFailures = "WorkerLogUploadFailures"
+
+	/*
 		the number of times the worker log upload timed out
 	*/
 	WorkerLogUploadTimeouts = "workerLogUploadTimeouts"

--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -486,22 +486,22 @@ const (
 	WorkerTimeSinceLastContactGauge_ms = "timeSinceLastContactGauge_ms"
 
 	/*
-		the number of times the worker uploaded a log to storage
+		the number of times the worker uploaded a log(stdout/stderr/stdlog) to storage
 	*/
 	WorkerUploads = "workerUploads"
 
 	/*
-		the number of times the worker log upload failed
+		the number of times the worker log(stdout/stderr/stdlog) upload failed
 	*/
-	WorkerLogUploadFailures = "WorkerLogUploadFailures"
+	WorkerLogUploadFailures = "workerLogUploadFailures"
 
 	/*
-		the number of times the worker log upload timed out
+		the number of times the worker log(stdout/stderr/stdlog) upload timed out
 	*/
 	WorkerLogUploadTimeouts = "workerLogUploadTimeouts"
 
 	/*
-		the number of times the worker log upload was retried
+		the number of times the worker log(stdout/stderr/stdlog) upload was retried
 	*/
 	WorkerLogUploadRetries = "workerLogUploadRetries"
 
@@ -512,7 +512,7 @@ const (
 	WorkerLogUploadLatency_ms = "workerLogUploadLatency_ms"
 
 	/*
-		the overall time spent uploading logs(stderr, stdout & stdlog)
+		the overall time spent uploading all three logs(stderr, stdout & stdlog)
 	*/
 	WorkerUploadLatency_ms = "workerUploadLatency_ms"
 

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -369,7 +369,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 		rts.execEnd = stamp()
 		rts.outputStart = stamp()
 		if runType == runner.RunTypeScoot {
-			var stdlogUrl, stderrUrl, stdoutUrl string
+			var stderrUrl, stdoutUrl string
 			// only upload logs to a permanent location if a log uploader is initialized
 			if inv.uploader != nil {
 				uploadTimer := inv.stat.Latency(stats.WorkerUploadLatency_ms).Time()
@@ -386,7 +386,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 				var isAborted bool
 				// upload stdlog
 				logId := fmt.Sprintf("%s_%s/%s", cmd.JobID, logUid, stdlogName)
-				stdlogUrl, isAborted = inv.uploadLog(logId, stdlog.AsFile(), abortCh)
+				_, isAborted = inv.uploadLog(logId, stdlog.AsFile(), abortCh)
 				if isAborted {
 					return runner.AbortStatus(id, tags.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID, Tag: cmd.Tag})
 
@@ -415,7 +415,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 
 			// Note: only modify stdout/stderr refs when logs are successfully uploaded to storage
 			if stderrUrl != "" {
-				status.StderrRef = stdlogUrl
+				status.StderrRef = stderrUrl
 			}
 			if stdoutUrl != "" {
 				status.StdoutRef = stdoutUrl

--- a/runner/runners/log_uploader.go
+++ b/runner/runners/log_uploader.go
@@ -1,0 +1,31 @@
+package runners
+
+// LogUploader provides functionality to upload logs to permanent storage, used by invoker to upload task logs
+type LogUploader interface {
+	UploadLog(blobId string, filepath string, cancelCh chan struct{}) (string, error)
+}
+
+// Implementations for testing (single_test.go)
+
+// Creates a new LogUploader that will not do anything
+func NewNoopLogUploader() *NoopLogUploader {
+	return &NoopLogUploader{}
+}
+
+type NoopLogUploader struct{}
+
+func (u *NoopLogUploader) UploadLog(blobId string, filepath string, cancelCh chan struct{}) (string, error) {
+	return "fake_blob_url", nil
+}
+
+// Creates a new LogUploader that will just block on cancel channel
+func NewWaitingLogUploader() *NoopWaitingLogUploader {
+	return &NoopWaitingLogUploader{}
+}
+
+type NoopWaitingLogUploader struct{}
+
+func (u *NoopWaitingLogUploader) UploadLog(blobId string, filepath string, cancelCh chan struct{}) (string, error) {
+	<-cancelCh
+	return "fake_blob_url", nil
+}

--- a/runner/runners/polling_test.go
+++ b/runner/runners/polling_test.go
@@ -16,7 +16,7 @@ func setupPoller() (*execers.SimExecer, *ChaosRunner, runner.Service) {
 	ex := execers.NewSimExecer()
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeInvalidFiler(), IDC: nil}
-	single := NewSingleRunner(ex, filerMap, NewNullOutputCreator(), nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{})
+	single := NewSingleRunner(ex, filerMap, NewNullOutputCreator(), nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{}, nil)
 	chaos := NewChaosRunner(single)
 	var nower runner.StatusQueryNower
 	nower = chaos

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -84,6 +84,7 @@ func NewQueueRunner(
 	rID runner.RunnerID,
 	preprocessors []func() error,
 	postprocessors []func() error,
+	uploader LogUploader,
 ) runner.Service {
 	if stat == nil {
 		stat = stats.NilStatsReceiver()
@@ -98,7 +99,7 @@ func NewQueueRunner(
 	}
 
 	statusManager := NewStatusManager(history)
-	inv := NewInvoker(exec, filerMap, output, stat, dirMonitor, rID, preprocessors, postprocessors)
+	inv := NewInvoker(exec, filerMap, output, stat, dirMonitor, rID, preprocessors, postprocessors, uploader)
 
 	controller := &QueueController{
 		statusManager: statusManager,
@@ -167,8 +168,9 @@ func NewSingleRunner(
 	rID runner.RunnerID,
 	preprocessors []func() error,
 	postprocessors []func() error,
+	uploader LogUploader,
 ) runner.Service {
-	return NewQueueRunner(exec, filerMap, output, 0, stat, dirMonitor, rID, preprocessors, postprocessors)
+	return NewQueueRunner(exec, filerMap, output, 0, stat, dirMonitor, rID, preprocessors, postprocessors, uploader)
 }
 
 // QueueController maintains a queue of commands to run (up to capacity).

--- a/runner/runners/queue_test.go
+++ b/runner/runners/queue_test.go
@@ -218,7 +218,7 @@ func setup(capacity int, interval time.Duration, t *testing.T) *env {
 
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeInvalidFilerUpdater(updater), IDC: nil}
-	r := NewQueueRunner(sim, filerMap, outputCreator, capacity, nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{})
+	r := NewQueueRunner(sim, filerMap, outputCreator, capacity, nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{}, nil)
 
 	return &env{sim: sim, r: r, u: updater, uc: &updateCount}
 }

--- a/runner/runners/single_test.go
+++ b/runner/runners/single_test.go
@@ -105,6 +105,34 @@ func TestAbort(t *testing.T) {
 	}
 }
 
+func TestAbortLogUpload(t *testing.T) {
+	defer teardown(t)
+	sim := execers.NewSimExecer()
+	outputCreator, err := NewHttpOutputCreator("")
+	if err != nil {
+		panic(err)
+	}
+	filerMap := runner.MakeRunTypeMap()
+	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeInvalidFiler(), IDC: nil}
+	r := NewSingleRunner(sim, filerMap, outputCreator, nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{}, NewWaitingLogUploader())
+	args := []string{"complete 0"}
+	runID := run(t, r, args)
+	assertWait(t, r, runID, running(), args...)
+	time.Sleep(10 * time.Millisecond)
+	r.Abort(runID)
+	// use r.Status instead of assertWait so that we make sure it's aborted immediately, not eventually
+	st, _, err := r.Status(runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertStatus(t, st, aborted(), args...)
+
+	st, err = r.Abort(runner.RunID("not-a-run-id"))
+	if err == nil {
+		t.Fatal(err)
+	}
+}
+
 func TestMemCap(t *testing.T) {
 	defer teardown(t)
 	// Command to increase memory by 1MB every .1s until we hit 50MB after 5s.
@@ -115,7 +143,7 @@ func TestMemCap(t *testing.T) {
 	e := os_execer.NewBoundedExecer(execer.Memory(10*1024*1024), stats.NilStatsReceiver())
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeNoopFiler(tmp), IDC: nil}
-	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{})
+	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{}, nil)
 	if _, err := r.Run(cmd); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -145,7 +173,7 @@ func TestStats(t *testing.T) {
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeNoopFiler(tmp), IDC: nil}
 	dirMonitor := stats.NewDirsMonitor([]stats.MonitorDir{{StatSuffix: "cwd", Directory: "./"}})
-	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), stat, dirMonitor, runner.EmptyID, []func() error{}, []func() error{})
+	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), stat, dirMonitor, runner.EmptyID, []func() error{}, []func() error{}, NewNoopLogUploader())
 
 	// Add initial idle time to keep the avg idle time above 50ms
 	time.Sleep(50 * time.Millisecond)
@@ -172,26 +200,22 @@ func TestStats(t *testing.T) {
 	// Run and abort a command to verify abort starts the recording of idle time
 	runID := assertRun(t, r, running(), args...)
 	r.Abort(runID)
-	time.Sleep(50 * time.Millisecond)
 
-	// third run to avoid doing a stats check while the idle latency is being measured
-	// (results in data race otherwise)
-	assertRun(t, r, running(), args...)
 	if !stats.StatsOk("", statsReg, t,
 		map[string]stats.Rule{
-			stats.WorkerUploadLatency_ms + ".avg":   {Checker: stats.FloatGTTest, Value: 0.0},
-			stats.WorkerDownloadLatency_ms + ".avg": {Checker: stats.FloatGTTest, Value: 0.0},
-			stats.WorkerUploads:                     {Checker: stats.Int64EqTest, Value: 1},
-			stats.WorkerDownloads:                   {Checker: stats.Int64EqTest, Value: 1},
-			stats.WorkerTaskLatency_ms + ".avg":     {Checker: stats.FloatGTTest, Value: 0.0},
-			stats.CommandDirUsageKb + "_cwd":        {Checker: stats.Int64EqTest, Value: 0},
-			stats.WorkerIdleLatency_ms + ".avg":     {Checker: stats.FloatGTTest, Value: 50.0},
-			stats.WorkerIdleLatency_ms + ".count":   {Checker: stats.Int64EqTest, Value: 3},
+			stats.WorkerUploadLatency_ms + ".avg":    {Checker: stats.FloatGTTest, Value: 0.0},
+			stats.WorkerLogUploadLatency_ms + ".avg": {Checker: stats.FloatGTTest, Value: 0.0},
+			stats.WorkerDownloadLatency_ms + ".avg":  {Checker: stats.FloatGTTest, Value: 0.0},
+			stats.WorkerUploads:                      {Checker: stats.Int64EqTest, Value: 3},
+			stats.WorkerDownloads:                    {Checker: stats.Int64EqTest, Value: 1},
+			stats.WorkerTaskLatency_ms + ".avg":      {Checker: stats.FloatGTTest, Value: 0.0},
+			stats.CommandDirUsageKb + "_cwd":         {Checker: stats.Int64EqTest, Value: 0},
+			stats.WorkerIdleLatency_ms + ".avg":      {Checker: stats.FloatGTTest, Value: 50.0},
+			stats.WorkerIdleLatency_ms + ".count":    {Checker: stats.Int64EqTest, Value: 2},
 		}) {
 		t.Fatal("stats check did not pass.")
 	}
 }
-
 func TestTimeout(t *testing.T) {
 	defer teardown(t)
 	stat, statsReg := setupTest()
@@ -201,7 +225,7 @@ func TestTimeout(t *testing.T) {
 	e := execers.NewSimExecer()
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeNoopFiler(tmp), IDC: nil}
-	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), stat, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{})
+	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), stat, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{}, nil)
 	if _, err := r.Run(cmd); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -241,7 +265,7 @@ func newRunner() (runner.Service, *execers.SimExecer) {
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeInvalidFiler(), IDC: nil}
 
-	r := NewSingleRunner(sim, filerMap, outputCreator, nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{})
+	r := NewSingleRunner(sim, filerMap, outputCreator, nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{}, nil)
 	return r, sim
 }
 

--- a/scheduler/server/stateful_scheduler_test.go
+++ b/scheduler/server/stateful_scheduler_test.go
@@ -283,7 +283,7 @@ func Test_StatefulScheduler_TaskGetsMarkedCompletedAfterMaxRetriesFailedRuns(t *
 		ex.ExecError = errors.New("Test - failed to exec")
 		filerMap := runner.MakeRunTypeMap()
 		filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeInvalidFiler(), IDC: nil}
-		return runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{})
+		return runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{}, nil)
 	}
 
 	s := makeStatefulSchedulerDeps(deps)
@@ -768,7 +768,7 @@ func getDepsWithSimWorker() (*schedulerDeps, []*execers.SimExecer) {
 			ex := execers.NewSimExecer()
 			filerMap := runner.MakeRunTypeMap()
 			filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeInvalidFiler(), IDC: nil}
-			runner := runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{})
+			runner := runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{}, nil)
 			return runner
 		},
 		config: SchedulerConfiguration{

--- a/scheduler/setup/worker/makers.go
+++ b/scheduler/setup/worker/makers.go
@@ -22,7 +22,7 @@ func MakeDoneWorker() runner.Service {
 	ex := execers.NewDoneExecer()
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeInvalidFiler(), IDC: nil}
-	r := runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{})
+	r := runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{}, nil)
 	chaos := runners.NewChaosRunner(r)
 	chaos.SetDelay(time.Duration(50) * time.Millisecond)
 	return chaos
@@ -33,5 +33,5 @@ func MakeSimWorker() runner.Service {
 	ex := execers.NewSimExecer()
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeInvalidFiler(), IDC: nil}
-	return runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{})
+	return runners.NewSingleRunner(ex, filerMap, runners.NewNullOutputCreator(), nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{}, nil)
 }

--- a/worker/starter/start_server.go
+++ b/worker/starter/start_server.go
@@ -2,11 +2,11 @@ package starter
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/twitter/scoot/common/endpoints"
 	"github.com/twitter/scoot/common/stats"
@@ -57,6 +57,7 @@ func StartServer(
 	stat *stats.StatsReceiver,
 	preprocessors []func() error,
 	postprocessors []func() error,
+	uploader runners.LogUploader,
 ) {
 	// create worker object:
 	// worker support objects
@@ -69,7 +70,7 @@ func StartServer(
 		filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: gitFiler, IDC: db.InitDoneCh}
 	}
 	// the worker object
-	worker := runners.NewSingleRunner(execer, filerMap, oc, *stat, dirMonitor, rID, preprocessors, postprocessors)
+	worker := runners.NewSingleRunner(execer, filerMap, oc, *stat, dirMonitor, rID, preprocessors, postprocessors, uploader)
 
 	// add service wrappers
 	// thrift wrapper

--- a/worker/starter/start_server.go
+++ b/worker/starter/start_server.go
@@ -2,11 +2,11 @@ package starter
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/twitter/scoot/common/endpoints"
 	"github.com/twitter/scoot/common/stats"

--- a/worker/workerserver/main.go
+++ b/worker/workerserver/main.go
@@ -69,6 +69,7 @@ func main() {
 		&stat,
 		[]func() error{},
 		[]func() error{},
+		nil,
 	)
 }
 


### PR DESCRIPTION
Existing way of uploading logs: create a snapshot of log directory and upload to bundlestore
Updated way: upload logs directly to a permanent storage by implementing LogUploader, skipping output snapshot creation and ingestion