### PR TITLE
Ability to override worker memory utilization function

### DIFF
--- a/runner/execer/os/easy_test.go
+++ b/runner/execer/os/easy_test.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 func TestAll(t *testing.T) {
-	e := NewBoundedExecer(0, nil)
+	e := NewBoundedExecer(0, nil, nil)
 
 	// TODO(dbentley): factor out an assertRun method
 	cmd := scootexecer.Command{
@@ -53,7 +53,7 @@ func TestAll(t *testing.T) {
 }
 
 func TestOutput(t *testing.T) {
-	e := NewBoundedExecer(0, nil)
+	e := NewBoundedExecer(0, nil, nil)
 
 	var stdout, stderr bytes.Buffer
 
@@ -96,7 +96,7 @@ func TestMemUsage(t *testing.T) {
 			TaskID: "taskID1234",
 		},
 	}
-	e := NewBoundedExecer(0, nil)
+	e := NewBoundedExecer(0, nil, nil)
 	p, err := e.Exec(cmd)
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -143,7 +143,7 @@ func TestMemCap(t *testing.T) {
 		MemCh: memCh,
 	}
 	// Terminate nearly immediately, after memory grows to 1MB.
-	e := NewBoundedExecer(scootexecer.Memory(1024*1024), stats.NilStatsReceiver())
+	e := NewBoundedExecer(scootexecer.Memory(1024*1024), nil, stats.NilStatsReceiver())
 	p, err := e.Exec(cmd)
 	if err != nil {
 		t.Fatalf(err.Error())

--- a/runner/execer/os/execer.go
+++ b/runner/execer/os/execer.go
@@ -171,7 +171,7 @@ func (e *execer) monitorMem(p *process, memCh chan scootexecer.ProcessStatus) {
 			} else {
 				mem, err = e.pw.MemUsage(pid)
 			}
-			if err != nil{
+			if err != nil {
 				log.Debugf("Error getting memory utilization: %s", err)
 				e.stat.Gauge(stats.WorkerMemory).Update(-1)
 				continue

--- a/runner/execer/os/execer.go
+++ b/runner/execer/os/execer.go
@@ -217,7 +217,7 @@ func (e *execer) monitorMem(p *process, memCh chan scootexecer.ProcessStatus) {
 						"tag":         p.Tag,
 						"jobID":       p.JobID,
 						"taskID":      p.TaskID,
-					}).Infof("Memory utilization increased to %d, pid: %d", int(memUsagePct*100), pid)
+					}).Infof("Memory utilization increased to %d%%, pid: %d", int(memUsagePct*100), pid)
 
 				// Trace output with timeout since it seems CombinedOutput() sometimes fails to return.
 				if log.IsLevelEnabled(log.TraceLevel) {
@@ -232,7 +232,7 @@ func (e *execer) monitorMem(p *process, memCh chan scootexecer.ProcessStatus) {
 							"tag":    p.Tag,
 							"jobID":  p.JobID,
 							"taskID": p.TaskID,
-						}).Tracef("ps after increased memory utilization for pid %d", pid)
+						}).Debugf("ps after increased memory utilization for pid %d", pid)
 					cancel()
 				}
 

--- a/runner/execer/os/execer.go
+++ b/runner/execer/os/execer.go
@@ -30,19 +30,23 @@ type WriterDelegater interface {
 // Implements runner/execer.Execer
 type execer struct {
 	// Best effort monitoring of command to kill it if resident memory usage exceeds this cap
-	memCap scootexecer.Memory
-	stat   stats.StatsReceiver
-	pw     ProcessWatcher
+	memCap            scootexecer.Memory
+	getMemUtilization func() (int64, error)
+	stat              stats.StatsReceiver
+	pw                ProcessWatcher
 }
 
-// NewBoundedExecer returns an execer with a ProcGetter and, if non-zero values are provided, a memCap and a StatsReceiver
-func NewBoundedExecer(memCap scootexecer.Memory, stat stats.StatsReceiver) *execer {
+// NewBoundedExecer returns an execer with a ProcGetter and, if non-zero values are provided, a memCap, overriding memory utilization function, and a StatsReceiver
+func NewBoundedExecer(memCap scootexecer.Memory, getMemUtilization func() (int64, error), stat stats.StatsReceiver) *execer {
 	oe := &execer{pw: NewProcWatcher()}
 	if memCap != 0 {
 		oe.memCap = memCap
 	}
 	if stat != nil {
 		oe.stat = stat
+	}
+	if getMemUtilization != nil {
+		oe.getMemUtilization = getMemUtilization
 	}
 	return oe
 }
@@ -157,11 +161,19 @@ func (e *execer) monitorMem(p *process, memCh chan scootexecer.ProcessStatus) {
 			if _, err := e.pw.GetProcs(); err != nil {
 				log.Error(err)
 			}
-			mem, _ := e.pw.MemUsage(pid)
+			var mem scootexecer.Memory
+			// if not nil, use the provided function to get memory utilization,
+			// otherwise get the memory usage of the current process and its subprocesses
+			if e.getMemUtilization != nil {
+				memory, _ := e.getMemUtilization()
+				mem = scootexecer.Memory(memory)
+			} else {
+				mem, _ = e.pw.MemUsage(pid)
+			}
 			e.stat.Gauge(stats.WorkerMemory).Update(int64(mem))
-			// Aborting process, above memCap
+			// Abort process if calculated memory utilization is above memCap
 			if mem >= e.memCap {
-				msg := fmt.Sprintf("Cmd exceeded MemoryCap, aborting %d: %d > %d (%v)", pid, mem, e.memCap, p.cmd.Args)
+				msg := fmt.Sprintf("Cmd exceeded MemoryCap, aborting process %d: %d > %d (%v)", pid, mem, e.memCap, p.cmd.Args)
 				log.WithFields(
 					log.Fields{
 						"mem":    mem,
@@ -197,7 +209,7 @@ func (e *execer) monitorMem(p *process, memCh chan scootexecer.ProcessStatus) {
 						"tag":         p.Tag,
 						"jobID":       p.JobID,
 						"taskID":      p.TaskID,
-					}).Infof("Increased mem_cap utilization for pid %d to %d", pid, int(memUsagePct*100))
+					}).Infof("Memory utilization increased to %d, pid: %d", int(memUsagePct*100), pid)
 
 				// Trace output with timeout since it seems CombinedOutput() sometimes fails to return.
 				if log.IsLevelEnabled(log.TraceLevel) {
@@ -212,7 +224,7 @@ func (e *execer) monitorMem(p *process, memCh chan scootexecer.ProcessStatus) {
 							"tag":    p.Tag,
 							"jobID":  p.JobID,
 							"taskID": p.TaskID,
-						}).Tracef("ps after increasing mem_cap utilization for pid %d", pid)
+						}).Tracef("ps after increased memory utilization for pid %d", pid)
 					cancel()
 				}
 

--- a/runner/execer/os/execer_test.go
+++ b/runner/execer/os/execer_test.go
@@ -103,7 +103,7 @@ func TestParentProcGroupAndChildren(t *testing.T) {
 }
 
 func TestAbortSigterm(t *testing.T) {
-	e := NewBoundedExecer(0, nil)
+	e := NewBoundedExecer(0, nil, nil)
 	cmd := scootexecer.Command{
 		Argv: []string{"sleep", "1000"},
 	}

--- a/runner/runners/setup.go
+++ b/runner/runners/setup.go
@@ -23,8 +23,8 @@ type module struct{}
 // Install installs functions for creating a new Runner.
 func (m module) Install(b *ice.MagicBag) {
 	b.PutMany(
-		func(m execer.Memory, s stats.StatsReceiver) execer.Execer {
-			return execers.MakeSimExecerInterceptor(execers.NewSimExecer(), osexec.NewBoundedExecer(m, s))
+		func(m execer.Memory, getMemFunc func() (int64, error), s stats.StatsReceiver) execer.Execer {
+			return execers.MakeSimExecerInterceptor(execers.NewSimExecer(), osexec.NewBoundedExecer(m, getMemFunc, s))
 		},
 		func() runner.RunnerID {
 			// suitable local testing purposes, but a production implementation would supply a unique ID

--- a/runner/runners/single_test.go
+++ b/runner/runners/single_test.go
@@ -137,7 +137,7 @@ func TestMemCap(t *testing.T) {
 	str := `import time; exec("x=[]\nfor i in range(50):\n x.append(' ' * 1024*1024)\n time.sleep(.1)")`
 	cmd := &runner.Command{Argv: []string{"python3", "-c", str}}
 	tmp, _ := ioutil.TempDir("", "")
-	e := os_execer.NewBoundedExecer(execer.Memory(10*1024*1024), stats.NilStatsReceiver())
+	e := os_execer.NewBoundedExecer(execer.Memory(10*1024*1024), nil, stats.NilStatsReceiver())
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeNoopFiler(tmp), IDC: nil}
 	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{}, nil)

--- a/worker/starter/start_server.go
+++ b/worker/starter/start_server.go
@@ -57,12 +57,13 @@ func StartServer(
 	stat *stats.StatsReceiver,
 	preprocessors []func() error,
 	postprocessors []func() error,
+	memUtilizationFunc func() (int64, error),
 	uploader runners.LogUploader,
 ) {
 	// create worker object:
 	// worker support objects
 	memory := execer.Memory(memCap)
-	execer := execers.MakeSimExecerInterceptor(execers.NewSimExecer(), osexec.NewBoundedExecer(memory, *stat))
+	execer := execers.MakeSimExecerInterceptor(execers.NewSimExecer(), osexec.NewBoundedExecer(memory, memUtilizationFunc, *stat))
 
 	var filerMap runner.RunTypeMap = runner.MakeRunTypeMap()
 	if db != nil {

--- a/worker/workerserver/main.go
+++ b/worker/workerserver/main.go
@@ -70,6 +70,7 @@ func main() {
 		[]func() error{},
 		[]func() error{},
 		nil,
+		nil,
 	)
 }
 


### PR DESCRIPTION
Introduce ability to pass a memory utilization function when starting workerserver. If passed, use this function to calculate worker memory and compare against the memory cap.