### PR TITLE
Add ability to mark worker unhealthy in case of persistent high memory & add monitoring metrics

### DIFF
--- a/common/errors/exit_codes.go
+++ b/common/errors/exit_codes.go
@@ -19,7 +19,7 @@ const (
 
 	PostProcessingFailureExitCode = 230
 
-	CouldNotExecExitCode = 240
+	CouldNotExecExitCode                 = 240
 	HighInitialMemoryUtilizationExitCode = 241
 
 	PostExecFailureExitCode = 250

--- a/common/errors/exit_codes.go
+++ b/common/errors/exit_codes.go
@@ -20,6 +20,7 @@ const (
 	PostProcessingFailureExitCode = 230
 
 	CouldNotExecExitCode = 240
+	HighInitialMemoryUtilizationExitCode = 241
 
 	PostExecFailureExitCode = 250
 )

--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -436,6 +436,16 @@ const (
 	WorkerMemory = "memory"
 
 	/*
+		record high memory utilization on task start
+	*/
+	WorkerHighInitialMemoryUtilization = "highInitialMemoryUtilization"
+
+	/*
+		record when worker memory consumption exceed soft memory cap
+	*/
+	WorkerMemoryCapExceeded = "memoryCapExceeded"
+
+	/*
 		A gauge used to indicate if the worker is currently running a task or if is idling
 	*/
 	WorkerRunningTask = "runningTask"
@@ -471,9 +481,9 @@ const (
 	WorkerServerStartedGauge = "workerStartGauge"
 
 	/*
-		record when a worker service kills itself
+		record when a worker service becomes unhealthy
 	*/
-	WorkerServerKillGauge = "workerKillGauge"
+	WorkerUnhealthy = "workerUnhealthy"
 
 	/*
 		The time it takes to run the task (including snapshot handling)

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -344,7 +344,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 				"taskID":   cmd.TaskID,
 				"status":   st,
 				"checkout": co.Path(),
-			}).Infof("Cmd exceeded MemoryCap, aborting %v", cmd.String())
+			}).Infof(st.Error)
 		inv.stat.Counter(stats.WorkerMemoryCapExceeded).Inc(1)
 		runStatus = getPostExecRunStatus(st, id, cmd)
 		runStatus.Error = st.Error

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -146,11 +146,13 @@ func NewQueueRunner(
 				statusManager.UpdateService(runner.ServiceStatus{Initialized: false, Error: initErr})
 			} else {
 				statusManager.UpdateService(runner.ServiceStatus{Initialized: true, IsHealthy: true})
+				stat.Gauge(stats.WorkerUnhealthy).Update(0)
 				controller.startUpdateTickers()
 			}
 		}()
 	} else {
 		statusManager.UpdateService(runner.ServiceStatus{Initialized: true, IsHealthy: true})
+		stat.Gauge(stats.WorkerUnhealthy).Update(0)
 		controller.startUpdateTickers()
 	}
 

--- a/runner/runners/single_test.go
+++ b/runner/runners/single_test.go
@@ -190,7 +190,7 @@ func TestHighInitialMem(t *testing.T) {
 		AllRuns: true,
 		States:  runner.MaskForState(runner.FAILED),
 	}
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 	if runs, svcStatus, err := r.Query(query, runner.Wait{Timeout: 5 * time.Second}); err != nil {
 		t.Fatalf(err.Error())
 	} else if len(runs) != 1 {

--- a/runner/runners/single_test.go
+++ b/runner/runners/single_test.go
@@ -10,6 +10,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/twitter/scoot/common/errors"
 	"github.com/twitter/scoot/common/log/hooks"
 	"github.com/twitter/scoot/common/stats"
 	"github.com/twitter/scoot/runner"
@@ -132,15 +133,16 @@ func TestAbortLogUpload(t *testing.T) {
 
 func TestMemCap(t *testing.T) {
 	defer teardown(t)
-	// Command to increase memory by 1MB every .1s until we hit 50MB after 5s.
+	// Command to increase memory by 1MB every .2s until we hit 25MB after 5s.
 	// Test that limiting the memory to 10MB causes the command to abort.
-	str := `import time; exec("x=[]\nfor i in range(50):\n x.append(' ' * 1024*1024)\n time.sleep(.1)")`
+	str := `import time; exec("x=[]\nfor i in range(25):\n x.append(' ' * 1024*1024)\n time.sleep(.2)")`
 	cmd := &runner.Command{Argv: []string{"python3", "-c", str}}
 	tmp, _ := ioutil.TempDir("", "")
-	e := os_execer.NewBoundedExecer(execer.Memory(10*1024*1024), nil, stats.NilStatsReceiver())
+	stat, statsReg := setupTest()
+	e := os_execer.NewBoundedExecer(execer.Memory(10*1024*1024), nil, stat)
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeNoopFiler(tmp), IDC: nil}
-	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), nil, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{}, nil)
+	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), stat, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{}, nil)
 	if _, err := r.Run(cmd); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -157,6 +159,57 @@ func TestMemCap(t *testing.T) {
 	} else if runs[0].ExitCode != 1 || !strings.Contains(runs[0].Error, "Cmd exceeded MemoryCap, aborting") {
 		status, _, err := r.StatusAll()
 		t.Fatalf("Expected result with error message mentioning MemoryCap & an exit code of 1, got: %v -- status %v err %v -- exitCode %v", runs, status, err, runs[0].ExitCode)
+	}
+
+	// verify metrics
+	if !stats.StatsOk("", statsReg, t,
+		map[string]stats.Rule{
+			stats.WorkerMemoryCapExceeded: {Checker: stats.Int64EqTest, Value: 1},
+		}) {
+		t.Fatal("stats check did not pass.")
+	}
+}
+
+func TestHighInitialMem(t *testing.T) {
+	defer teardown(t)
+	// Command to increase memory to 10MB as soon as process starts, as an attempt to mock behavior
+	// where memory consumption is detected to be above memory cap as soon as memory monitoring starts
+	str := `import time; exec("x=[]\nfor i in range(1):\n x.append(' ' * 10*1024*1024)\n time.sleep(.5)")`
+	cmd := &runner.Command{Argv: []string{"python3", "-c", str}}
+	tmp, _ := ioutil.TempDir("", "")
+	stat, statsReg := setupTest()
+	e := os_execer.NewBoundedExecer(execer.Memory(1*1024*1024), nil, stat)
+	filerMap := runner.MakeRunTypeMap()
+	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeNoopFiler(tmp), IDC: nil}
+	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), stat, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{}, nil)
+	if _, err := r.Run(cmd); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	query := runner.Query{
+		AllRuns: true,
+		States:  runner.MaskForState(runner.FAILED),
+	}
+
+	if runs, svcStatus, err := r.Query(query, runner.Wait{Timeout: 20 * time.Second}); err != nil {
+		t.Fatalf(err.Error())
+	} else if len(runs) != 1 {
+		t.Fatalf("Expected a single FAILED run, got %v", len(runs))
+	} else if runs[0].ExitCode != errors.HighInitialMemoryUtilizationExitCode || !strings.Contains(runs[0].Error, "Cmd exceeded MemoryCap, aborting") {
+		status, _, err := r.StatusAll()
+		t.Fatalf("Expected result with error message mentioning MemoryCap & an exit code of 1, got: %v -- status %v err %v -- exitCode %v", runs, status, err, runs[0].ExitCode)
+	} else if svcStatus.IsHealthy {
+		t.Fatalf("Expected service status IsHealthy to be false, got %v", svcStatus.IsHealthy)
+	}
+
+	// verify metrics
+	if !stats.StatsOk("", statsReg, t,
+		map[string]stats.Rule{
+			stats.WorkerUnhealthy:                    {Checker: stats.Int64EqTest, Value: 1},
+			stats.WorkerHighInitialMemoryUtilization: {Checker: stats.Int64EqTest, Value: 1},
+			stats.WorkerMemoryCapExceeded:            {Checker: stats.Int64EqTest, Value: 1},
+		}) {
+		t.Fatal("stats check did not pass.")
 	}
 }
 

--- a/runner/runners/single_test.go
+++ b/runner/runners/single_test.go
@@ -139,7 +139,7 @@ func TestMemCap(t *testing.T) {
 	cmd := &runner.Command{Argv: []string{"python3", "-c", str}}
 	tmp, _ := ioutil.TempDir("", "")
 	stat, statsReg := setupTest()
-	e := os_execer.NewBoundedExecer(execer.Memory(10*1024*1024), nil, stat)
+	e := os_execer.NewBoundedExecer(execer.Memory(15*1024*1024), nil, stat)
 	filerMap := runner.MakeRunTypeMap()
 	filerMap[runner.RunTypeScoot] = snapshot.FilerAndInitDoneCh{Filer: snapshots.MakeNoopFiler(tmp), IDC: nil}
 	r := NewSingleRunner(e, filerMap, NewNullOutputCreator(), stat, stats.NopDirsMonitor, runner.EmptyID, []func() error{}, []func() error{}, nil)

--- a/runner/status.go
+++ b/runner/status.go
@@ -160,6 +160,6 @@ type ServiceStatus struct {
 }
 
 func (s ServiceStatus) String() string {
-	return fmt.Sprintf("--- Service Status ---\n\tInitialized: %t\n\tIsHealthy: %t\n",
+	return fmt.Sprintf("--- Service Status ---\n\tInitialized : %t\n\tIsHealthy : %t\n",
 		s.Initialized, s.IsHealthy)
 }

--- a/runner/status.go
+++ b/runner/status.go
@@ -160,5 +160,6 @@ type ServiceStatus struct {
 }
 
 func (s ServiceStatus) String() string {
-	return fmt.Sprintf("--- Service Status ---\n\tInitialized:%t\n\tIsHealthy:%t\n", s.Initialized, s.IsHealthy)
+	return fmt.Sprintf("--- Service Status ---\n\tInitialized: %t\n\tIsHealthy: %t\n",
+		s.Initialized, s.IsHealthy)
 }

--- a/runner/status.go
+++ b/runner/status.go
@@ -155,9 +155,10 @@ func CompleteStatus(runID RunID, snapshotID string, exitCode errors.ExitCode, ta
 // This is for overall runner status, just 'initialized' status and error for now.
 type ServiceStatus struct {
 	Initialized bool
+	IsHealthy   bool
 	Error       error
 }
 
 func (s ServiceStatus) String() string {
-	return fmt.Sprintf("--- Service Status ---\n\tInitialized:%t\n", s.Initialized)
+	return fmt.Sprintf("--- Service Status ---\n\tInitialized:%t\n\tIsHealthy:%t\n", s.Initialized, s.IsHealthy)
 }

--- a/scheduler/server/stateful_scheduler.go
+++ b/scheduler/server/stateful_scheduler.go
@@ -230,13 +230,13 @@ func NewStatefulScheduler(
 	nodeReadyFn := func(node cc.Node) (bool, time.Duration) {
 		run := rf(node)
 		st, svc, err := run.StatusAll()
-		if err != nil || !svc.Initialized {
+		if err != nil || !svc.Initialized || !svc.IsHealthy {
 			if svc.Error != nil {
 				log.WithFields(
 					log.Fields{
 						"node": node,
 						"err":  svc.Error,
-					}).Info("received service err during init of new node")
+					}).Info("received service err")
 				return false, 0
 			}
 			return false, config.ReadyFnBackoff

--- a/worker/api/thrift/worker.thrift
+++ b/worker/api/thrift/worker.thrift
@@ -35,7 +35,8 @@ struct RunStatus {
 struct WorkerStatus {
   1: required list<RunStatus> runs  # All runs
   2: required bool initialized      # True if the worker has finished with any long-running init tasks.
-  3: required string error          # Set when a general worker error unrelated to a specific run has occurred.
+  3: required bool isHealthy        # True if the worker is in a healthy state to accept new tasks.
+  4: required string error          # Set when a general worker error unrelated to a specific run has occurred.
 }
 
 struct RunCommand {

--- a/worker/client/client.go
+++ b/worker/client/client.go
@@ -134,7 +134,7 @@ func (c *simpleClient) Status(id runner.RunID) (runner.RunStatus, runner.Service
 	if ws.Error != "" {
 		svcErr = errors.New(ws.Error)
 	}
-	svc := runner.ServiceStatus{Initialized: ws.Initialized, IsHealthy: ws.IsHealthy,  Error: svcErr}
+	svc := runner.ServiceStatus{Initialized: ws.Initialized, IsHealthy: ws.IsHealthy, Error: svcErr}
 	for _, p := range ws.Runs {
 		if p.RunID == id {
 			return p, svc, nil

--- a/worker/client/client.go
+++ b/worker/client/client.go
@@ -153,7 +153,7 @@ func (c *simpleClient) StatusAll() ([]runner.RunStatus, runner.ServiceStatus, er
 	if ws.Error != "" {
 		svcErr = errors.New(ws.Error)
 	}
-	return ws.Runs, runner.ServiceStatus{Initialized: ws.Initialized, Error: svcErr}, nil
+	return ws.Runs, runner.ServiceStatus{Initialized: ws.Initialized, IsHealthy: ws.IsHealthy, Error: svcErr}, nil
 }
 
 func (c *simpleClient) QueryNow(q runner.Query) ([]runner.RunStatus, runner.ServiceStatus, error) {

--- a/worker/client/client.go
+++ b/worker/client/client.go
@@ -134,7 +134,7 @@ func (c *simpleClient) Status(id runner.RunID) (runner.RunStatus, runner.Service
 	if ws.Error != "" {
 		svcErr = errors.New(ws.Error)
 	}
-	svc := runner.ServiceStatus{Initialized: ws.Initialized, Error: svcErr}
+	svc := runner.ServiceStatus{Initialized: ws.Initialized, IsHealthy: ws.IsHealthy,  Error: svcErr}
 	for _, p := range ws.Runs {
 		if p.RunID == id {
 			return p, svc, nil

--- a/worker/domain/api.go
+++ b/worker/domain/api.go
@@ -19,6 +19,7 @@ import (
 type WorkerStatus struct {
 	Runs        []runner.RunStatus
 	Initialized bool
+	IsHealthy   bool
 	Error       string
 }
 
@@ -27,7 +28,7 @@ func ThriftWorkerStatusToDomain(thrift *worker.WorkerStatus) WorkerStatus {
 	for _, r := range thrift.Runs {
 		runs = append(runs, ThriftRunStatusToDomain(r))
 	}
-	return WorkerStatus{runs, thrift.Initialized, thrift.Error}
+	return WorkerStatus{runs, thrift.Initialized, thrift.IsHealthy, thrift.Error}
 }
 
 func DomainWorkerStatusToThrift(domain WorkerStatus) *worker.WorkerStatus {
@@ -36,6 +37,7 @@ func DomainWorkerStatusToThrift(domain WorkerStatus) *worker.WorkerStatus {
 	for _, r := range domain.Runs {
 		thrift.Runs = append(thrift.Runs, DomainRunStatusToThrift(r))
 		thrift.Initialized = domain.Initialized
+		thrift.IsHealthy = domain.IsHealthy
 		thrift.Error = domain.Error
 	}
 	return thrift

--- a/worker/domain/gen-go/worker/ttypes.go
+++ b/worker/domain/gen-go/worker/ttypes.go
@@ -592,11 +592,13 @@ func (p *RunStatus) String() string {
 // Attributes:
 //  - Runs
 //  - Initialized
+//  - IsHealthy
 //  - Error
 type WorkerStatus struct {
 	Runs        []*RunStatus `thrift:"runs,1,required" json:"runs"`
 	Initialized bool         `thrift:"initialized,2,required" json:"initialized"`
-	Error       string       `thrift:"error,3,required" json:"error"`
+	IsHealthy   bool         `thrift:"isHealthy,3,required" json:"isHealthy"`
+	Error       string       `thrift:"error,4,required" json:"error"`
 }
 
 func NewWorkerStatus() *WorkerStatus {
@@ -611,6 +613,10 @@ func (p *WorkerStatus) GetInitialized() bool {
 	return p.Initialized
 }
 
+func (p *WorkerStatus) GetIsHealthy() bool {
+	return p.IsHealthy
+}
+
 func (p *WorkerStatus) GetError() string {
 	return p.Error
 }
@@ -621,6 +627,7 @@ func (p *WorkerStatus) Read(iprot thrift.TProtocol) error {
 
 	var issetRuns bool = false
 	var issetInitialized bool = false
+	var issetIsHealthy bool = false
 	var issetError bool = false
 
 	for {
@@ -646,6 +653,11 @@ func (p *WorkerStatus) Read(iprot thrift.TProtocol) error {
 			if err := p.readField3(iprot); err != nil {
 				return err
 			}
+			issetIsHealthy = true
+		case 4:
+			if err := p.readField4(iprot); err != nil {
+				return err
+			}
 			issetError = true
 		default:
 			if err := iprot.Skip(fieldTypeId); err != nil {
@@ -664,6 +676,9 @@ func (p *WorkerStatus) Read(iprot thrift.TProtocol) error {
 	}
 	if !issetInitialized {
 		return thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("Required field Initialized is not set"))
+	}
+	if !issetIsHealthy {
+		return thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("Required field IsHealthy is not set"))
 	}
 	if !issetError {
 		return thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("Required field Error is not set"))
@@ -701,8 +716,17 @@ func (p *WorkerStatus) readField2(iprot thrift.TProtocol) error {
 }
 
 func (p *WorkerStatus) readField3(iprot thrift.TProtocol) error {
-	if v, err := iprot.ReadString(); err != nil {
+	if v, err := iprot.ReadBool(); err != nil {
 		return thrift.PrependError("error reading field 3: ", err)
+	} else {
+		p.IsHealthy = v
+	}
+	return nil
+}
+
+func (p *WorkerStatus) readField4(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadString(); err != nil {
+		return thrift.PrependError("error reading field 4: ", err)
 	} else {
 		p.Error = v
 	}
@@ -720,6 +744,9 @@ func (p *WorkerStatus) Write(oprot thrift.TProtocol) error {
 		return err
 	}
 	if err := p.writeField3(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField4(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -766,14 +793,27 @@ func (p *WorkerStatus) writeField2(oprot thrift.TProtocol) (err error) {
 }
 
 func (p *WorkerStatus) writeField3(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("error", thrift.STRING, 3); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 3:error: ", p), err)
+	if err := oprot.WriteFieldBegin("isHealthy", thrift.BOOL, 3); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 3:isHealthy: ", p), err)
 	}
-	if err := oprot.WriteString(string(p.Error)); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T.error (3) field write error: ", p), err)
+	if err := oprot.WriteBool(bool(p.IsHealthy)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.isHealthy (3) field write error: ", p), err)
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 3:error: ", p), err)
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 3:isHealthy: ", p), err)
+	}
+	return err
+}
+
+func (p *WorkerStatus) writeField4(oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin("error", thrift.STRING, 4); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 4:error: ", p), err)
+	}
+	if err := oprot.WriteString(string(p.Error)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.error (4) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 4:error: ", p), err)
 	}
 	return err
 }

--- a/worker/starter/server.go
+++ b/worker/starter/server.go
@@ -126,6 +126,8 @@ func (h *handler) QueryWorker() (*worker.WorkerStatus, error) {
 	st, svc, err := h.run.StatusAll()
 	if err != nil {
 		ws.Error = err.Error()
+	} else if svc.Error != nil {
+		ws.Error = svc.Error.Error()
 	}
 	ws.Initialized = svc.Initialized
 	ws.IsHealthy = svc.IsHealthy

--- a/worker/starter/server.go
+++ b/worker/starter/server.go
@@ -128,6 +128,7 @@ func (h *handler) QueryWorker() (*worker.WorkerStatus, error) {
 		ws.Error = err.Error()
 	}
 	ws.Initialized = svc.Initialized
+	ws.IsHealthy = svc.IsHealthy
 
 	for _, status := range st {
 		if status.State.IsDone() {

--- a/worker/starter/start_server.go
+++ b/worker/starter/start_server.go
@@ -27,11 +27,19 @@ type WorkerStatusHTTPHandler struct {
 
 func (h *WorkerStatusHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, svcStatus, err := h.svc.QueryNow(runner.Query{})
-	if err == nil && svcStatus.Initialized {
+	if err == nil {
+		if !svcStatus.Initialized {
+			fmt.Fprintf(w, "not initialized")
+			return
+		}
+		if !svcStatus.IsHealthy{
+			fmt.Fprintf(w, "failed")
+			return
+		}
 		fmt.Fprintf(w, "ok")
 		return
 	}
-	fmt.Fprintf(w, "not initialized")
+	fmt.Fprintf(w, err.Error())
 }
 
 type servers struct {

--- a/worker/starter/start_server.go
+++ b/worker/starter/start_server.go
@@ -32,7 +32,7 @@ func (h *WorkerStatusHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 			fmt.Fprintf(w, "not initialized")
 			return
 		}
-		if !svcStatus.IsHealthy{
+		if !svcStatus.IsHealthy {
 			fmt.Fprintf(w, "failed")
 			return
 		}

--- a/worker/starter/start_server.go
+++ b/worker/starter/start_server.go
@@ -33,7 +33,7 @@ func (h *WorkerStatusHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 			return
 		}
 		if !svcStatus.IsHealthy {
-			fmt.Fprintf(w, "failed")
+			fmt.Fprintf(w, "not healthy")
 			return
 		}
 		fmt.Fprintf(w, "ok")


### PR DESCRIPTION
**Problem**

Workers can get into bad states where they continuously have high memory consumption exceeding the soft cap threshold(could be due to persistent processes or memory leaks from previous runs). This would fail tasks with the memory cap exceeded exception as soon as they start running. Fixing these workers would require manual intervention to kill and have the worker reassigned to a fresh, uncorrupted host.

**Solution**

Add ability to mark worker status as unhealthy if memory consumption is observed to be higher than the threshold as soon as a task starts, and allow scheduler to query if the worker is unhealthy. The scheduler marks unhealthy workers as suspended to prevent further tasks from being scheduled on the corrupt host. The unhealthy suspended worker nodes are also marked lost by the scheduler since we don't yet have a way to recover an unhealthy node. The worker health check API(/health) can be used to identify and setup an automatic restart mechanism. Also, record metrics for better monitoring and tracking of memory related errors.