### PR TITLE
Display user's processes info in task log when high memory consumption is detected, for debugging reasons

### DIFF
--- a/runner/execer/os/process_watcher.go
+++ b/runner/execer/os/process_watcher.go
@@ -123,7 +123,7 @@ func (opw *procWatcher) LogProcs(p *process, level log.Level, w io.Writer) {
 			"taskID": p.TaskID,
 		}).Log(level, fmt.Sprintf("ps after increased memory utilization for pid %d", p.cmd.Process.Pid))
 
-	if w != nil{
+	if w != nil {
 		w.Write([]byte(fmt.Sprintf("\nps after increased memory utilization for pid %d:\n\n", p.cmd.Process.Pid)))
 		w.Write(ps)
 	}

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -328,7 +328,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 				"tag":    cmd.Tag,
 				"jobID":  cmd.JobID,
 				"taskID": cmd.TaskID,
-			}).Info("Run timedout")
+			}).Error("Run timedout")
 		runStatus = runner.TimeoutStatus(id,
 			tags.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID, Tag: cmd.Tag})
 	case st := <-memCh:
@@ -344,7 +344,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 				"taskID":   cmd.TaskID,
 				"status":   st,
 				"checkout": co.Path(),
-			}).Infof(st.Error)
+			}).Errorf(st.Error)
 		inv.stat.Counter(stats.WorkerMemoryCapExceeded).Inc(1)
 		runStatus = getPostExecRunStatus(st, id, cmd)
 		runStatus.Error = st.Error


### PR DESCRIPTION
Record the output of ps command in task log when the memory cap is exceeded either on task start or when the task is running. This will improve the memory consumption visibility and be useful for debugging any zombie processes.